### PR TITLE
Update airlinecodes.txt

### DIFF
--- a/rootfs/usr/share/planefence/airlinecodes.txt
+++ b/rootfs/usr/share/planefence/airlinecodes.txt
@@ -660,7 +660,7 @@ BNT,Bentiu Air Transport,BENTIU AIR,Sudan
 BNV,Benane Aviation Corporation,BENANE,Mauritania
 BNW,British North West Airlines,BRITISH NORTH,United Kingdom
 BNX,LAI - Línea Aérea IAACA,AIR BARINAS,Venezuela
-BNZ,Aerolíneas Bonanza,AERO BONANZA,Mexico
+BNZ,Bonza,BONZA,Australia
 BOA,Boniair,KUMANOVO,Macedonia
 BOB,Backbone A/S,BACKBONE,Denmark
 BOC,Aerobona,AEROBONA,Mexico


### PR DESCRIPTION
airlinecodes.txt: Change BNZ to Bonza, [an Australian airline](https://en.wikipedia.org/wiki/Bonza). Aerolíneas Bonanza [apparently hasn't existed](https://en.wikipedia.org/wiki/Aerocaribe#History) for 48 years.