### PR TITLE
Plane-Alert Exclusions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,14 +16,10 @@ on:
     branches:
       - main
     # Don't trigger if it's just a documentation update
-    paths-ignore:
-      - "**.md"
-      - "**.MD"
-      - "**.yml"
-      - "LICENSE"
-      - ".gitattributes"
-      - ".gitignore"
-      - ".dockerignore"
+    paths:
+      - "rust/**"
+      - "Dockerfile**"
+      - "rootfs/**"
 
 # Set workflow-wide environment variables
 #  - REPO: repo name on dockerhub

--- a/README-nginx-rev-proxy.md
+++ b/README-nginx-rev-proxy.md
@@ -1,6 +1,8 @@
 # How to install and set up a reverse web proxy for use with @Mikenye's ADSB container collection
 
 - [How to install and set up a reverse web proxy for use with @Mikenye's ADSB container collection](#how-to-install-and-set-up-a-reverse-web-proxy-for-use-with-mikenyes-adsb-container-collection)
+	- [How To Do Things A Lot Easier Than Described Here](#how-to-do-things-a-lot-easier-than-described-here)
+	- [Introduction](#introduction)
 	- [Acknowledgements](#acknowledgements)
 	- [Installation of NGINX, a small web server with reverse-proxy capabilities](#installation-of-nginx-a-small-web-server-with-reverse-proxy-capabilities)
 	- [Configuration of NGINX as a reverse web proxy](#configuration-of-nginx-as-a-reverse-web-proxy)
@@ -9,10 +11,18 @@
 	- [Example `/etc/nginx/locations.conf` file](#example-etcnginxlocationsconf-file)
 
 
+## How To Do Things A Lot Easier Than Described Here
+
+We have created a container that implements a fullfledged reverse web proxy, that is easy to deploy and even easier to configure.
+
+You can find that container [here](https://sdr-enthusiasts/docker-reversewebproxy).
+
+## Introduction
+
 In Mikenye's excellent [gitbook](https://mikenye.gitbook.io/ads-b/) on how to quickly set up a number of containers to receive and process ADSB aircraft telemetry,
 you probably have created a bunch of containers that each provide a web service on their own port. This is a bit hard to manage, especially if you need to now open a large range of ports on your firewall to point at these services.
 
-This README describes how you can set up a "reverse web proxy" that allows you to point to point https://mysite.com/aaaa to something like http://internalhost1:8080/xxxx, and repeat this for each of the containers or web services. Additionally, it (optionally) will redirect any non-encrypted "http://" request to a secure "https://" request, enabling you to access your web services via SSL.
+This README describes how you can set up a "reverse web proxy" that allows you to point to point `https://mysite.com/aaaa` to something like `http://internalhost1:8080/xxxx`, and repeat this for each of the containers or web services. Additionally, it (optionally) will redirect any non-encrypted "http://" request to a secure "https://" request, enabling you to access your web services via SSL.
 
 There are NO changes needed to the containers. All you need is to take a quick inventory of the web services you have and the machines / ports they live on. You can do this by (for example) reading the `docker-compose.yml` files that show which services and ports are exposed.
 
@@ -29,11 +39,13 @@ There are NO changes needed to the containers. All you need is to take a quick i
 4. Do `sudo apt-get install nginx`
 
 ## Configuration of NGINX as a reverse web proxy
+
 1. Edit the config file: `sudo nano -l /etc/nginx/nginx.conf` and make the following changes:
-    - Once your proxy is configured / tested / stable, you may want to switch logging off (near lines 41/42):
-      `access_log /var/log/nginx/access.log;` -> `access_log off;`
-      `#error_log /var/log/nginx/error.log;` -> `error_log off;`
-    Then save and exit
+
+- Once your proxy is configured / tested / stable, you may want to switch logging off (near lines 41/42):
+`access_log /var/log/nginx/access.log;` -> `access_log off;`
+`#error_log /var/log/nginx/error.log;` -> `error_log off;`
+- Then save and exit
 
 2. Test. At this time, http://mysite.com (using the external or internal address) should render a template web page.
 
@@ -51,16 +63,17 @@ This will create an SSL certificate for you that is valid for 90 days. For renew
 5. In `/etc/nginx`, create a file called `locations.conf`. In this file, you will add your proxy redirects. Use `localhost` or `127.0.0.1` for ports on the local machine. See an example of this file below - adapt it to your own needs
 
 6. Now edit /etc/nginx/sites-available/default. There will be 3 sections that start with `server {` (potentially more that are commented out).
-    - The first section is for connections to the standard http port
-    - The second section is for connections to the SSL (https) port
-    - The third section rewrites any incoming "http" request into a "https" request
-    - For each `server` section, just before the closing `}`, add the following line:
+
+- The first section is for connections to the standard http port
+- The second section is for connections to the SSL (https) port
+- The third section rewrites any incoming "http" request into a "https" request
+- For each `server` section, just before the closing `}`, add the following line:
   
 ```text
 include /etc/nginx/locations.conf;
 ```
 
-7. Now, you're done! Restart the nginx server with `sudo systemctl restart nginx` and start testing!
+1. Now, you're done! Restart the nginx server with `sudo systemctl restart nginx` and start testing!
 
 ## Troubleshooting and known issues
 
@@ -175,8 +188,10 @@ server {
 ```
 
 ## Example `/etc/nginx/locations.conf` file
+
 Note - this is the file from my own setup. I have a bunch of service spread around machines and ports, and each `location` entry redirects a request from http://mysite.com/xxxx to wherever the webserver for xxxx is located on my subnet. It won't work directly for anyone else, but feel free to use it as an example.
-```
+
+```apacheconf
 location /readsb/ {
 	proxy_pass http://10.0.0.191:8080/;                                                                                                
 } 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ In the `docker-compose.yml` file, you should configure the following:
 
 #### Plane-Alert Exclusions
 
-In some circumstances you may wish to blacklist certain planes, or types of planes, from appearing in Plane-Alert and its Mastodon and Discord posts. This may be desireable if, for example, you're located near a military flight training base, where you could be flooded with dozens of notifications about T-6 Texan training aircraft every day, which could drown out more interesting planes. To that end, excluding planes can be accomplished using the `PA_EXCLUSIONS=` parameter in `/opt/adsb/planefence/config/planefence.config`. Currently, you may exclude whole ICAO Types (such as `TEX2` to remove all T-6 Texans), specific ICAO hexes (e.g. `AE1ECB`), specific registrations and tail codes (e.g. `N24HD` or `92-03327`), or any freeform string (e.g. `UC-12`, `Mayweather`, `Kid Rock`). Multiple exclusions should be separated by commas. It is case insensitive. An example:
+In some circumstances you may wish to blacklist certain planes, or types of planes, from appearing in Plane-Alert and its Mastodon and Discord posts. This may be desireable if, for example, you're located near a military flight training base, where you could be flooded with dozens of notifications about T-6 Texan training aircraft every day, which could drown out more interesting planes. To that end, excluding planes can be accomplished using the `PA_EXCLUSIONS=` parameter in `/opt/adsb/planefence/config/planefence.config`. Currently, you may exclude whole ICAO Types (such as `TEX2` to remove all T-6 Texans), specific ICAO hexes (e.g. `AE1ECB`), specific registrations and tail codes (e.g. `N24HD` or `92-03327`), or any freeform string (e.g. `UC-12`, `Mayweather`, `Kid Rock`). Multiple exclusions should be separated by commas. Exclusions are case insensitive and spaces **must** be escaped with a slash `\`. An example:
 ```yml
-PA_EXCLUSIONS=tex2,AE06D9,ae27fe,Floyd Mayweather,UC-12W
+PA_EXCLUSIONS=tex2,AE06D9,ae27fe,Floyd\ Mayweather,UC-12W
 ```
 This would exclude *all* T-6 Texans, the planes with ICAO hexes `AE06D9` (a Marine Corps UC-12F Huron) and `AE27FE` (a Coast Guard MH-60T), any planes with "Floyd Mayweather" anywhere in the database entry, and any planes with "UC-12W" anywhere in the database entry. URLs and image links are intentionally not searched.
 
@@ -142,7 +142,9 @@ Planefence and Plane-Alert keep a limited amount of data available. By default, 
 The Planefence and Plane-Alert APIs accept awk-style Regular Expressions as arguments. For example, a tail number starting with N, followed by 1 digit, followed by 1 or more digits or letters would be represented by this RegEx: `n[0-9][0-9A-Z]*` .  Query arguments are case-insensitive: looking for `n` or for `N` yields the same results.
 Each query must contain at least one of the parameters listed below. Optionally, the `type` parameter indicates the output type. Accepted values are `json` or `csv`; if omitted, `json` is the default value. (These argument values must be provided in lowercase.)
 Note that the `call` parameter (see below) will start with `@` followed by the call (tail number or flight number as reported via ADS-B/MLAT/UAT) if the entry was tweeted. So make sure to start your `call` query with `^@?` to include both tweeted an non-tweeted calls.
+
 #### Planefence Query parameters
+
 | Parameter | Description | Example |
 |---|---|---|
 | `hex` | Hex ID to return | https://planeboston.com/planefence/pf_query.php?hex=^A[AB][A-F0-9]*&type=csv returns a CSV with any Planefence records of which the Hex IDs that start with A, followed by A or B, followed by 0 or more hexadecimal digits |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # Docker-Planefence
 
+- [Docker-Planefence](#docker-planefence)
+  - [What is it?](#what-is-it)
+  - [Who is it for?](#who-is-it-for)
+  - [Install PlaneFence - Prerequisites](#install-planefence---prerequisites)
+    - [Getting ready](#getting-ready)
+    - [Planefence Configuration](#planefence-configuration)
+      - [Initial docker configuration](#initial-docker-configuration)
+      - [Planefence Settings Configuration](#planefence-settings-configuration)
+      - [Applying your setup](#applying-your-setup)
+  - [What does it look like when it's running?](#what-does-it-look-like-when-its-running)
+  - [API access to your data](#api-access-to-your-data)
+    - [Introduction](#introduction)
+    - [API parameters and usage examples](#api-parameters-and-usage-examples)
+      - [Planefence Query parameters](#planefence-query-parameters)
+      - [Plane-Alert Query parameters](#plane-alert-query-parameters)
+  - [Troubleshooting](#troubleshooting)
+  - [Getting help](#getting-help)
+
+
 ## What is it?
 
 This repository contains Planefence, which is an add-on to `ultrafeeder`, `readsb`, `dump1090`, or `dump1090-fa` (referred to herein as `your Feeder Station`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## What is it?
 
-This repository contains Planefence, which is an add-on to `ultrafeeder`, `readsb`, `dump1090`, or `dump1090-fa` (referred to herein as `your Feeder Station`.
+This repository contains Planefence, which is an add-on to `ultrafeeder`, `readsb`, `dump1090`, or `dump1090-fa` (referred to herein as `your Feeder Station`).
 
 Planefence will create a log of aircraft heard by your Feeder Station that are within a "fence", that is, less than a certain distance and lower than a certain
 altitude from your station. This log is displayed on a website and is also made available in daily CSV files.
@@ -41,7 +41,7 @@ Here are some assumptions or prerequisites:
 
 - You are already familiar the `dump1090` family of ADS-B software (for example, `ultrafeeder`, `readsb`, `tar1090`, `dump1090`, or `dump1090-fa`), how to deploy it, and the hardware needed. Ideally, you have your ADS-B station already up and running.
 - You know how to deploy Docker images to your machine. If you don't -- it's actually quite simple. It makes installation of new components really easy. [Mikenye's excellent Gitbook](https://mikenye.gitbook.io/ads-b/) contains a step-by-step guide, and [here](https://github.com/sdr-enthusiasts/docker-install) you can find a quick install script.
-- You use `docker-compose`. This README has been written assuming `docker-compose`. If you don't have it, feel free to `apt-get install` it. It should be easy to convert the `docker-compose.yml` instructions to a command-line `docker run` string, but you are on your own to do this.
+- You use `docker compose`. This README has been written assuming `docker compose`. If you don't have it, feel free to `apt-get install` it. It should be easy to convert the `docker-compose.yml` instructions to a command-line `docker run` string, but you are on your own to do this.
 - Further support is provided at the #planefence channel at the [SDR Enthusiasts Discord Server](https://discord.gg/VDT25xNZzV). If you need immediate help, please tag "@k1xt" to your message.
 
 ## Install PlaneFence - Prerequisites
@@ -51,13 +51,13 @@ Note - this guide assumes that `/home/pi` is your home directory. If it is not (
 There must already be an instance of `ultrafeeder`, `tar1090`, `dump1090[-fa]`, or `readsb` connected to a SDR somewhere in reach of your Planefence machine:
 
 - This could be in the same stack of containers, separately on the same machine, or even on another machine.
-- It is important to enable SBS data on port 30003 on that instance. PlaneFence will use this to get its data. See the Troubleshooting section for help to get this done
+- It is important to enable SBS data on port 30003 on that instance. PlaneFence will use this to get its data. See the [Troubleshooting](#troubleshooting) section for help to get this done.
 
 ### Getting ready
 
-1. If you are adding this to an existing stack of docker containers on your machine, you can add the information from this project to your existing `docker-compose.yml`.
+1. If you are adding this to an existing stack of Docker containers on your machine, you can add the information from this project to your existing `docker-compose.yml`.
 2. If you are not adding this to an existing container stack, you should create a project directory: `sudo mkdir -p /opt/planefence && sudo chmod a+rwx /opt/planefence && cd /opt/planefence` . Then add a new `docker-compose.yml` there.
-3. Get the template Docker-compose.yml file from here:
+3. Get the template `docker-compose.yml` file from here:
 
 ```bash
 curl -s https://raw.githubusercontent.com/sdr-enthusiasts/docker-planefence/main/docker-compose.yml > docker-compose.yml
@@ -72,7 +72,7 @@ In the `docker-compose.yml` file, you should configure the following:
 - IMPORTANT: The image, by default, points at the release image. For the DEV version, change this: `image: ghcr.io/sdr-enthusiasts/docker-planefence:dev`
 - IMPORTANT: Update `TZ=America/New_York` to whatever is appropriate for you. Note that this variable is case sensitive
 - There are 2 volumes defined. My suggestion is NOT to change these unless you know what you are doing
-- After you exit the editor, start the container (`docker-compose up -d`). The first time you do this, it can take a minute or so.
+- After you exit the editor, start the container (`docker compose up -d`). The first time you do this, it can take a minute or so.
 - Monitor the container (`docker logs -f planefence`). At first start-up, it should be complaining about not being configure. That is expected behavior.
 - Once you see the warnings about `planefence.config` not being available, press CTRL-C to get the command prompt.
 
@@ -84,7 +84,7 @@ In the `docker-compose.yml` file, you should configure the following:
 - OPTIONAL: `sudo nano /opt/adsb/planefence/config/planefence-ignore.txt`. In this file, you can add aircraft that PlaneFence will ignore. If there are specific planes that fly too often over your home, add them here. Use 1 line per entry, and the entry can be a ICAO, flight number, etc. You can even use regular expressions if you want. Be careful -- we use this file as an input to a "grep" filter. If you put something that is broad (`.*` for example), then ALL PLANES will be filtered out.
 - OPTIONAL: `sudo nano /opt/adsb/planefence/config/airlinecodes.txt`. This file maps the first 3 characters of the flight number to the names of the airlines. We scraped this list from a Wikipedia page, and it is by no means complete. Feel free to add more to them -- please add an issue at https://github.com/sdr-enthusiasts/docker-planefence/issues so we can add your changes to the default file.
 - OPTIONAL: If you configured Twitter support before, `sudo nano /opt/adsb/planefence/config/.twurlrc`. You can add your back-up TWURLRC file here, if you want.
-- OPTIONAL: Configure tweets to be sent. For details, see these instructions: https://github.com/kx1t/docker-planefence/blob/main/README-planetweet.md
+- OPTIONAL: Configure tweets to be sent. For details, see these instructions: [README](README-planetweet.md)
 - OPTIONAL: `sudo nano /opt/adsb/planefence/config/plane-alert-db.txt`. This is the list of tracking aircraft of Plane-Alert. It is prefilled with the planes of a number of "interesting" political players. Feel free to add your own, delete what you don't want to see, etc. Just follow the same format.
 - OPTIONAL: If you have multiple containers running on different web port, and you would like to consolidate them all under a single host name, then you should consider installing a "reverse web proxy". This can be done quickly and easily - see instructions [here](https://github.com/kx1t/docker-planefence/README-nginx-rev-proxy.md).
 - OPTIONAL: If you have a soundcard and microphone, adding NoiseCapt is as easy as hooking up the hardware and running another container. You can add this to your existing `docker-compose.yml` file, or run it on a different machine on the same subnet. Instructions are [here](https://github.com/kx1t/docker-noisecapt/).
@@ -120,7 +120,7 @@ Also note that after adding exclusions, any pre-existing entries for those exclu
 #### Applying your setup
 
 - If you made a bunch of changes for the first time, you should restart the container. In the future, most updates to `/opt/adsb/planefence/config/planefence.config` will be picked up automatically
-- You can restart the Planefence container by doing: `pushd /opt/adsb && docker-compose up -d planefence --force-recreate && popd`
+- You can restart the Planefence container by doing: `pushd /opt/adsb && docker compose up -d planefence --force-recreate && popd`
 
 ## What does it look like when it's running?
 
@@ -139,7 +139,7 @@ Planefence and Plane-Alert keep a limited amount of data available. By default, 
 
 ### API parameters and usage examples
 
-The Planefence and Plane-Alert APIs accept awk-style Regular Expressions as arguments. For example, a tail number starting with N, followed by 1 digit, followed by 1 or more digits or letters would be represented by this RegEx: `n[0-9][0-9A-Z]*` .  Querie arguments are case-insensitive: looking for `n` or for `N` yield the same results.
+The Planefence and Plane-Alert APIs accept awk-style Regular Expressions as arguments. For example, a tail number starting with N, followed by 1 digit, followed by 1 or more digits or letters would be represented by this RegEx: `n[0-9][0-9A-Z]*` .  Query arguments are case-insensitive: looking for `n` or for `N` yields the same results.
 Each query must contain at least one of the parameters listed below. Optionally, the `type` parameter indicates the output type. Accepted values are `json` or `csv`; if omitted, `json` is the default value. (These argument values must be provided in lowercase.)
 Note that the `call` parameter (see below) will start with `@` followed by the call (tail number or flight number as reported via ADS-B/MLAT/UAT) if the entry was tweeted. So make sure to start your `call` query with `^@?` to include both tweeted an non-tweeted calls.
 #### Planefence Query parameters
@@ -170,12 +170,15 @@ Note that the `call` parameter (see below) will start with `@` followed by the c
 - Check the logs: `docker logs -f planefence`. Some "complaining" about lost connections or files not found is normal, and will correct itself after a few minutes of operation. The logs will be quite explicit if it wants you to take action
 - Check the website: http://myip:8088 should update every 80 seconds (starting about 80 seconds after the initial startup). The top of the website shows a last-updated time and the number of messages received from the feeder station.
 - Plane-alert will appear at http://myip:8088/plane-alert
-- Twitter setup is complex and Elon will ban you if you publish anything about one of his planes. [Here](https://github.com/sdr-enthusiasts/docker-planefence#setting-up-tweeting)'s a description on what to do. We advice you to skip Twitter and send notifications to [Mastodon](https://github.com/sdr-enthusiasts/docker-planefence/README-Mastodon.md) instead.
+- Twitter setup is complex and Elon will ban you if you publish anything about one of his planes. [Here](https://github.com/sdr-enthusiasts/docker-planefence#setting-up-tweeting)'s a description on what to do. We advise you to skip Twitter and send notifications to [Mastodon](README-Mastodon.md) instead.
 - Error "We cannot reach {host} on port 30003". This could be caused by a few things:
-  - Did you set the correct hostname or IP address in `PF_SOCK30003HOST` in `planefence.config`? This can be either an IP address, or an external hostname, or the name of another container in the same stack.
+  - Did you set the correct hostname or IP address in `PF_SOCK30003HOST` in `planefence.config`? This can be:
+      - The name of another container in the same Docker compose stack, e.g., `ultrafeeder` or `tar1090`
+      - IP address or an external hostname to a different server
+      - IP address or an external hostname to the same server if the Docker instance of `ultrafeeder`, `tar1090`, etc. is in a different stack, e.g., adsb.im feeder image
   - Did you enable SBS (BaseStation -- *not* Beast!) output? Here are some hints on how to enable this:
-   - For non-containerized `dump1090[-fa]`/`readsb`/`tar1090`: add command line option `--net-sbs-port 30003`
-   - For containerized `readsb-protobuf`: add to the `environment:` section of your `docker-compose.yml` file:
+    - For non-containerized `dump1090[-fa]`/`readsb`/`tar1090`: add command line option `--net-sbs-port 30003`
+    - For containerized `readsb-protobuf`: add to the `environment:` section of your `docker-compose.yml` file:
   
       ```yaml
             - READSB_NET_SBS_OUTPUT_PORT=30003
@@ -183,8 +186,12 @@ Note that the `call` parameter (see below) will start with `@` followed by the c
       ```
 
     - For users of the `ultrafeeder` container, no additional changes should be needed (see below for enabling MLAT aircraft)
-    - if you are using a different container stack, then you should also add `- 30003:30003` to the `ports:` section
-   - For users of `ultrafeeder`, if you want to enabled MLAT, make sure to set the following parameter in the `ultrafeeder` environment variables: `- READSB_FORWARD_MLAT_SBS=true`
+  - If you are using multiple Docker container stacks, then you should also add `- 30003:30003` to the `ports:` section in the `docker-compose.yml` file that contains your `ultrafeeder`, `tar1090`, `readsb`, or service.
+  - For users of `ultrafeeder`, if you want to enabled MLAT, make sure to set the following parameter in the `ultrafeeder` environment variables:
+    
+    ```yaml
+          - READSB_FORWARD_MLAT_SBS=true
+    ```
 
 ## Getting help
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     restart: always
     shm_size: 1gb
     environment:
-      - MAP_ARGS=zoom=11&hideSidebar&hideButtons&mapDim=2.0&monochromeMarkers=ff0000&outlineColor=505050&iconScale=1.5
+      - MAP_ARGS=zoom=11&hideSidebar&hideButtons&mapDim=0.2&monochromeMarkers=ff0000&outlineColor=505050&iconScale=1.5
       - LOAD_SLEEP_TIME=10
       - BASE_URL=http://ultrafeeder
       - readsbpb_autogain:/run/autogain

--- a/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
+++ b/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
@@ -49,7 +49,7 @@ done
 
 if [[ $inhibit_update == "false" ]]; then
 	touch /usr/share/planefence/persist/.internal/plane-alert-db.txt
-	cat /tmp/alertlist*.txt |  tr -dc "[:alnum:][:blank:]:/?&=%#\$\\\[\].,\{\};\-_\n" | awk -F',' '!seen[$1]++'  >/usr/share/planefence/persist/.internal/plane-alert-db.txt 2>/dev/null
+	cat /tmp/alertlist*.txt |  tr -dc "[:alnum:][:blank:]+':/?&=%#\$\\\[\].,\{\};\-_\n" | awk -F',' '!seen[$1]++'  >/usr/share/planefence/persist/.internal/plane-alert-db.txt 2>/dev/null
 	EXCLUDE="$(sed -n 's|^\s*PA_EXCLUSIONS=\(.*\)|\1|p' /usr/share/planefence/persist/planefence.config)"
 	[[ "$EXCLUDE" != "" ]] && IFS="," read -ra EXCLUSIONS <<< "$EXCLUDE"
 	count_start="$(wc -l < /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
@@ -57,12 +57,16 @@ if [[ $inhibit_update == "false" ]]; then
 	do
 		if (("${#TYPE} >= 3")) && (("${#TYPE} <= 4"))
 		then
-			echo "$TYPE appears to be an ICAO type and is valid, removing."
+			echo "$TYPE appears to be an ICAO type and is valid, entries excluded:" "$(grep -ci "$TYPE" /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
 			sed -i "/,$TYPE,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
 		elif [[ "$TYPE" =~ ^[0-9a-fA-F]{6}$ ]]
 		then
-			echo "$TYPE appears to be an ICAO hex and is valid, removing."
+			echo "$TYPE appears to be an ICAO hex and is valid, entries excluded:" "$(grep -ci "$TYPE" /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
 			sed -r -i "/^$TYPE,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
+		elif [[ -n "$TYPE" ]]
+		then
+			echo "$TYPE appears to be a freeform search pattern, entries excluded:" "$(grep -ci "$TYPE" /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
+			sed -r -i "/,[A-Za-z0-9\-\.\+ ]*$TYPE[A-Za-z0-9\-\.\+ ]*,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
 		else
 			echo "$TYPE is invalid, skipping!"
 		fi

--- a/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
+++ b/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
@@ -50,7 +50,8 @@ done
 if [[ $inhibit_update == "false" ]]; then
 	touch /usr/share/planefence/persist/.internal/plane-alert-db.txt
 	cat /tmp/alertlist*.txt |  tr -dc "[:alnum:][:blank:]:/?&=%#\$\\\[\].,\{\};\-_\n" | awk -F',' '!seen[$1]++'  >/usr/share/planefence/persist/.internal/plane-alert-db.txt 2>/dev/null
-	EXCLUSIONS="$(sed -n 's|^\s*PA_EXCLUSIONS=\(.*\)|\1|p' /usr/share/planefence/persist/planefence.config)"
+	EXCLUDE="$(sed -n 's|^\s*PA_EXCLUSIONS=\(.*\)|\1|p' /usr/share/planefence/persist/planefence.config)"
+	[[ "$EXCLUDE" != "" ]] && IFS="," read -ra EXCLUSIONS <<< "$EXCLUDE"
 	count_start="$(wc -l < /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
 	for TYPE in "${EXCLUSIONS[@]}"
 	do

--- a/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
+++ b/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
@@ -58,7 +58,7 @@ if [[ $inhibit_update == "false" ]]; then
 		if (("${#TYPE} >= 3")) && (("${#TYPE} <= 4"))
 		then
 			echo "$TYPE is valid, removing."
-			sed -i "/,$TYPE,/d" /usr/share/planefence/persist/.internal/plane-alert-db.txt
+			sed -i "/,$TYPE,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
 		else
 			echo "$TYPE is invalid, skipping!"
 		fi

--- a/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
+++ b/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
@@ -50,6 +50,20 @@ done
 if [[ $inhibit_update == "false" ]]; then
 	touch /usr/share/planefence/persist/.internal/plane-alert-db.txt
 	cat /tmp/alertlist*.txt |  tr -dc "[:alnum:][:blank:]:/?&=%#\$\\\[\].,\{\};\-_\n" | awk -F',' '!seen[$1]++'  >/usr/share/planefence/persist/.internal/plane-alert-db.txt 2>/dev/null
+	EXCLUSIONS="$(sed -n 's|^\s*PA_EXCLUSIONS=\(.*\)|\1|p' /usr/share/planefence/persist/planefence.config)"
+	count_start="$(wc -l < /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
+	for TYPE in "${EXCLUSIONS[@]}"
+	do
+		if (("${#TYPE} >= 3")) && (("${#TYPE} <= 4"))
+		then
+			echo "$TYPE is valid, removing."
+			sed -i "/,$TYPE,/d" /usr/share/planefence/persist/.internal/plane-alert-db.txt
+		else
+			echo "$TYPE is invalid, skipping!"
+		fi
+	done
+	count_end="$(wc -l < /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
+	echo "$(("$count_start - $count_end")) entries excluded."
 	chmod a+r /usr/share/planefence/persist/.internal/plane-alert-db.txt
 	ln -sf /usr/share/planefence/persist/.internal/plane-alert-db.txt /usr/share/planefence/html/plane-alert/alertlist.txt
 else

--- a/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
+++ b/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
@@ -64,8 +64,10 @@ if [[ $inhibit_update == "false" ]]; then
 		fi
 	done
 	count_end="$(wc -l < /usr/share/planefence/persist/.internal/plane-alert-db.txt)"
-	echo "$(("$count_start - $count_end")) entries excluded."
+	if (("$count_start - $count_end")) > 0 
+		then echo "$(("$count_start - $count_end")) entries excluded."
 	chmod a+r /usr/share/planefence/persist/.internal/plane-alert-db.txt
+	fi
 	ln -sf /usr/share/planefence/persist/.internal/plane-alert-db.txt /usr/share/planefence/html/plane-alert/alertlist.txt
 else
 	echo "[$APPNAME][$(date)] At least one http retrieval failed, using old list!"

--- a/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
+++ b/rootfs/usr/share/plane-alert/get-pa-alertlist.sh
@@ -57,8 +57,12 @@ if [[ $inhibit_update == "false" ]]; then
 	do
 		if (("${#TYPE} >= 3")) && (("${#TYPE} <= 4"))
 		then
-			echo "$TYPE is valid, removing."
+			echo "$TYPE appears to be an ICAO type and is valid, removing."
 			sed -i "/,$TYPE,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
+		elif [[ "$TYPE" =~ ^[0-9a-fA-F]{6}$ ]]
+		then
+			echo "$TYPE appears to be an ICAO hex and is valid, removing."
+			sed -r -i "/^$TYPE,/Id" /usr/share/planefence/persist/.internal/plane-alert-db.txt
 		else
 			echo "$TYPE is invalid, skipping!"
 		fi

--- a/rootfs/usr/share/planefence/airlinecodes.txt
+++ b/rootfs/usr/share/planefence/airlinecodes.txt
@@ -1,3 +1,21 @@
+0MM,All America MX,,Mexico
+1CH,OneChina,,China
+1QA,Marysya Airlines,,Russia
+2CO,ConneX European Airline,,Austria
+2K2,Regionalia Uruguay,,Uruguay
+3FF,Fly Colombia ( Interliging Flights ),,Colombia
+4AA,Epic Holiday,,United States
+4SW,TEA Switzerland,,Switzerland
+6CC,Vuela Cuba,,Cuba
+7KK,All Colombia,,Colombia
+7ZC,All America CO,,Colombia
+8K8,All Australia,,Australia
+99F,All Africa,,South Africa
+9XX,Regionalia Venezuela,,Venezuela
+A1F,Atifly,,United States
+A9B,All America BR,,Brazil
+AA1,Aerolineas Africanas,,Guinea
+AAA,Ansett Australia,,Australia
 AAB,Abelag Aviation,ABG,Belgium
 AAC,Army Air Corps,ARMYAIR,United Kingdom
 AAD,Mann Air Ltd,Ambassador,United Kingdom
@@ -24,6 +42,7 @@ AAY,Allegiant Air,ALLEGIANT,United States
 AAZ,Asian Air,,Kyrgyzstan
 ABA,Aero-Beta,AEROBETA,Germany
 ABB,African Business and Transportations,AFRICAN BUSINESS,Democratic Republic of the Congo
+ABC,AirBridgeCargo,AIRBRIDGE CARGO,Russia
 ABD,Air Atlanta Icelandic,ATLANTA,Iceland
 ABE,Aban Air,ABAN,Iran
 ABF,Aerial Oy,SKYWINGS,Finland
@@ -31,6 +50,7 @@ ABG,Abakan-Avia,ABAKAN-AVIA,Russia
 ABH,Hokuriki-Koukuu Company,,Japan
 ABI,Antigua and Barbuda Airways,Anair,Antigua and Barbuda
 ABJ,Abaeté Linhas Aéreas,,Brazil
+ABK,Alberta Citylink,,Canada
 ABL,Air BC,AIRCOACH,Canada
 ABM,Aero Albatros,ALBATROS ESPANA,Spain
 ABN,Air Fret Senegal,,Senegal
@@ -60,58 +80,79 @@ ACK,Nantucket Airlines,ACK AIR,United States
 ACL,Itali Airlines,SPADA,Italy
 ACM,Air Caledonia,WEST CAL,Canada
 ACN,Central American Airlines,AEROCENTRO,Nicaragua
+ACO,Aero Comondu,,Mexico
 ACP,Astral Aviation,ASTRAL CARGO,Kenya
 ACQ,Aryan Cargo Express,,India
-ACR,Aerocenter, Escuela de Formación de Pilotos Privados de Avión,AEROCENTER,Spain
+ACR,Aerocenter,AEROCENTER,Spain
 ACS,Aircraft Sales and Services,AIRCRAFT SALES,Pakistan
 ACT,Flight Line,AMERICAN CHECK,United States
 ACU,Air Cargo Transportation System,AFRISPIRIT,Kenya
 ACV,Air Charter Service,,United Kingdom
 ACW,Royal Air Force,AIR CADET,United Kingdom
+ACX,Air Charters,,Canada
 ACY,Atlas Cargo Airlines,ATLAS CARGOLINES,Morocco
 ADA,Airservices Australia,AUSCAL,Australia
 ADB,Antonov Airlines,ANTONOV BUREAU,Ukraine
 ADC,AD Astra Executive Charter,AD ASTRA,Poland
 ADD,Advanced Air Co.,,Japan
-ADF,Ade, Aviación Deportiva,ADE AVIACION,Spain
+ADE,Ada Air,,Albania
+ADF,Ade Aviación Deportiva,ADE AVIACION,Spain
 ADG,Aerea Flying Training Organization,AEREA TRAINING,Spain
+ADH,Air One,,Italy
 ADI,Audeli Air,AUDELI,Spain
+ADJ,Abicar,,Ivory Coast
+ADK,ADC Airlines,,Nigeria
 ADL,Aero Dynamics,COTSWOLD,United Kingdom
+ADM,Aerolineas Dominicanas,,Dominican Republic
 ADN,Aero-Dienst,AERODIENST,Germany
 ADO,Air Do,AIR DO,Japan
 ADP,Aerodiplomatic,AERODIPLOMATIC,Mexico
 ADQ,Avion Taxi,AIR DATA,Canada
+ADR,Adria Airways,,Slovenia
 ADS,Aviones de Sonora,SONORAV,Mexico
 ADT,Arrendaminetos y Transportes Turisticos,ARRENDA-TRANS,Mexico
 ADU,Airdeal Oy,AIRDEAL,Finland
 ADV,Advanced Flight Training,ADVANCED,United Kingdom
+ADW,Air Andaman,,Thailand
 ADX,Anderson Aviation,ANDAX,United States
 ADY,Aerodyne,AERODYNE,United States
 ADZ,Avio Delta,,Bulgaria
 AEA,Air Europa,EUROPA,Spain
+AEB,Aero Benin,,Benin
+AEC,Aerocesar,AEROCESAR,Colombia
+AED,Aerotrans Airlines,,Russia
 AEE,Aegean Airlines,AEGEAN,Greece
 AEF,Aerea,,Spain
+AEG,Aerofumigaciones Sam,,Chile
 AEH,Aero4m,AEROCUTTER,Slovenia
 AEI,Air Italy Polska,POLISH BIRD,Poland
 AEJ,Air Express,KHAKI EXPRESS,Tanzania
 AEK,Aerocon,AEROCON,Bolivia
+AEL,Air Europe,,Italy
 AEM,Aero Madrid,AEROMADRID,Spain
+AEN,Aeroenlaces Nacionales,,Mexico
 AEO,Aeroservicios Ejecutivos Del Occidente,AERO OCCIDENTE,Mexico
 AEP,Aerotec Escuela de Pilotos,AEROTEC,Spain
 AEQ,Air Express,LUNA,Sweden
 AER,Alaska Central Express,ACE AIR,United States
 AES,Aerosur Paraguay,AEROPARAGUAY,Paraguay
+AET,Aeronautical Radio of Thailand,,Thailand
+AEU,Astraeus,,United Kingdom
 AEV,Aeroventas,AEROVENTAS,Mexico
+AEW,Aerosvit Airlines,,Ukraine
 AEX,Airway Express,AVCO,United States
 AEY,Air Italy,AIR ITALY,Italy
 AEZ,Aerial Transit,AERIAL TRANZ,United States
 AFA,Alfa Air,BLUE ALFA,Czech Republic
+AFB,American Falcon,,Argentina
 AFC,African West Air,AFRICAN WEST,Senegal
 AFD,Panorama Flight Service,AIRFED,United States
 AFE,Airfast Indonesia,AIRFAST,Indonesia
 AFF,Africa Airways,AFRIWAYS,Benin
 AFG,Ariana Afghan Airlines,ARIANA,Afghanistan
-AFI,Africaone,AFRICAWORLD,The Gambia
+AFH,Air Fecteau,,Canada
+AFI,Africaone,AFRICAWORLD,Gambia
+AFJ,Alliance,,Uganda
 AFK,Africa Air Links,AFRICA LINKS,Sierra Leone
 AFL,Aeroflot Russian Airlines,AEROFLOT,Russia
 AFM,Air Four,,Italy
@@ -121,30 +162,39 @@ AFP,Portuguese Air Force,PORTUGUESE AIR FORCE,Portugal
 AFQ,Alba Servizi Aerotrasporti,ALBA,Italy
 AFR,Air France,AIRFRANS,France
 AFS,Air Data,,United Kingdom
+AFU,Afrinat International Airlines,,Gambia
 AFV,Air Afrique Vacancies,AFRIQUE VACANCE,Côte d'Ivoire
 AFW,Africa World Airlines,BLACKSTAR,Ghana
+AFX,Airfreight Express,,United Kingdom
 AFY,Africa Chartered Services,AFRICA CHARTERED,Nigeria
 AFZ,Africa Freight Services,AFREIGHT,Zambia
 AGA,AG Air,GEOLINE,Georgia
+AGB,Air Service Gabon,,Gabon
 AGC,Arab Agricultural Aviation Company,AGRICO,Egypt
 AGE,Servicios Aéreos de Los Ángeles,AEROANGEL,Mexico
+AGF,Atlantic Gulf Airlines,,United States
 AGG,Algoma Airways,ALGOMA,Canada
 AGH,Altagna,ALTAGNA,France
 AGI,Aereo Transportes Los Angeles de America,ANGELES AMERICA,Mexico
 AGM,Air Guam,AIR GUAM,United States
+AGN,Air Gabon,,Gabon
 AGO,Angola Air Charter,ANGOLA CHARTER,Angola
 AGP,AERFI Group,AIR TARA,Ireland
+AGQ,Aerogala,,Chile
 AGR,United States Department Of Agriculture,AGRICULTURE,United States
 AGT,Amadeus IT Group,AMADEUS,Spain
 AGU,Angara Airlines,SARMA,Russia
 AGV,Air Glaciers,AIR GLACIERS,Switzerland
+AGW,Aero Gambia,,Gambia
+AGX,Aviogenex,,Serbia
 AGY,Aero Flight Service,FLIGHT GROUP,United States
 AGZ,Agrolet-Mci,AGROLET,Slovakia
 AHA,Air Alpha Greenland,AIR ALPHA,Denmark
 AHC,Azal Avia Cargo,AZALAVIACARGO,Azerbaijan
 AHD,Czech Air Handling,AIRHANDLING,Czech Republic
-AHE,Airport Helicopter Basel, Muller & Co.,AIRPORT HELICOPTER,Switzerland
+AHE,Airport Helicopter Basel Muller & Co.,AIRPORT HELICOPTER,Switzerland
 AHF,Aspen Helicopters,ASPEN,United States
+AHG,Aerochago Airlines,,Dominican Republic
 AHH,Airplanes Holdings,AIRHOLD,Ireland
 AHI,Servicios Aéreos de Chihuahua Aerochisa,AEROCHISA,Mexico
 AHK,Air Hong Kong,AIR HONG KONG,Hong Kong
@@ -153,10 +203,14 @@ AHM,Garrison Aviation,AIR HURON,Canada
 AHN,Air Hungaria,AIR HUNGARIA,Hungary
 AHO,Air Hamburg,AIR HAMBURG,Germany
 AHP,Aerochiapas,AEROCHIAPAS,Mexico
+AHR,Air Adriatic,,Croatia
 AHS,AHS Air International,HIGH SKY,Pakistan
 AHT,HTA Helicopteros,HELIAPRA,Portugal
 AHU,ABC Air Hungary,ABC HUNGARY,Hungary
+AHW,Aeromist-Kharkiv,,Ukraine
+AHX,Amakusa Airlines,AMAKUSA AIR,Japan
 AHY,Azerbaijan Airlines,AZAL,Azerbaijan
+AI0,Air Indus,,Pakistan
 AIA,Avies,AVIES,Estonia
 AIB,Airbus Industrie,AIRBUS INDUSTRIE,France
 AIC,Air India Limited,AIRINDIA,India
@@ -168,11 +222,13 @@ AIH,Air Incheon,AIR INCHEON,South Korea
 AII,Air Integra,INTEGRA,Canada
 AIJ,Interjet,ABC Aerolineas,Mexico
 AIK,African Airlines International Limited,AFRICAN AIRLINES,Kenya
+AIL,Air Illinois,,United States
 AIM,Trabajos Aéreos Murcianos,PIJO,Spain
 AIN,African International Airways,FLY CARGO,Swaziland
-AIO,Chief of Staff, United States Air Force,AIR CHIEF,United States
+AIO,Chief of Staff United States Air Force,AIR CHIEF,United States
 AIP,Alpine Air Express,ALPINE AIR,United States
 AIQ,Thai AirAsia,THAI ASIA,Thailand
+AIR,Airlift International,,United States
 AIS,Air Sureste,SURESTE,Spain
 AIT,Airest,,Estonia
 AIU,Alicante Internacional Airlines,ALIA,Spain
@@ -184,12 +240,14 @@ AIZ,Arkia Israel Airlines,ARKIA,Israel
 AJA,Afghan Jet International Airlines,AFGHAN JET,Afghanistan
 AJB,Aero JBR,AERO JBR,Mexico
 AJC,Bar Harbor Airlines,BAR HARBOR,United States
+AJE,Aero Jet Express,,Mexico
 AJF,Avia Consult Flugbetriebs,AVIACONSULT,Austria
 AJH,Aeroaljarafe,ALJARAFE,Spain
 AJI,Ameristar Jet Charter,AMERISTAR,United States
 AJJ,A2 Jet Leasing,ATLANTIC JET,United States
 AJK,Allied Air,BAMBI,Nigeria
 AJM,Air Jamaica,JAMAICA,Jamaica
+AJO,Aeroejecutivo,,Mexico
 AJP,Aero Jets Corporativos,AEROJETS,Mexico
 AJR,A-Jet Aviation Company,JET MONGOLIA,Mongolia
 AJS,Aeroejecutivos Colombia,AEROEJECUTIVOS,Colombia
@@ -198,6 +256,7 @@ AJU,Air Jetsul,AIRJETSUL,Portugal
 AJV,ANA & JP Express,AYJAY CARGO,Japan
 AJW,Alpha Jet International,ALPHAJET,United States
 AJX,Air Japan,AIR JAPAN,Japan
+AJY,Ajet,,Cyprus
 AKA,Air Korea Co. Ltd.,,Republic of Korea
 AKB,Aktjubavia,KARAB,Kazakhstan
 AKC,Arca Aerovías Colombianas Ltda.,ARCA,Colombia
@@ -209,21 +268,28 @@ AKK,Aklak Air,AKLAK,Canada
 AKL,Air Kiribati,,Kiribati
 AKM,Mak Air,MAKAIR,Kazakhstan
 AKN,Alkan Air,ALKAN AIR,Canada
+AKQ,Aerospace Consortium,MOONLIGHT,Kenya
 AKR,Aero Clinker,AERO CLINKER,Mexico
 AKT,Karat,AVIAKARAT,Russia
+AKW,Angkor Airways,,Cambodia
 AKX,Air Nippon Network Co. Ltd.,ALFA WING,Japan
 AKY,Yak-Service,YAK-SERVICE,Russia
 AKZ,AK Navigator,ABSOLUTE,Kazakhstan
+AL1,All Argentina,,Argentina
+AL2,All America,,United States
+AL3,All Asia,,China
 ALB,Aero Albatros,ALBATROS,Mexico
-ALC,Southern Jersey Airways, Inc.,ACOM,United States
+ALC,Southern Jersey Airways Inc.,ACOM,United States
 ALD,Albion Aviation,ALBION,United Kingdom
 ALE,Alliance Executive Jets,,Malta
 ALF,Allied Command Europe (Mobile Force),ACEFORCE,Belgium
 ALG,Air Logistics,AIRLOG,United States
+ALI,Airlift AS,BLUELIFT,Norway
 ALJ,Heli Ambulance Team,ALPIN HELI,Austria
 ALK,SriLankan Airlines,SRILANKAN,Sri Lanka
 ALL,Aerovallarta,VALLARTA,Mexico
-ALN,Alpha Jet, S.R.O.,TOLEMAC,Slovakia
+ALM,Air ALM,,Netherlands Antilles
+ALN,Alpha Jet S.R.O.,TOLEMAC,United States
 ALO,Allegheny Commuter Airlines,ALLEGHENY,United States
 ALP,Allpoints Jet,ALLPOINTS,China
 ALQ,Altair Aviation (1986),ALTAIR,Canada
@@ -232,7 +298,7 @@ ALS,Aeralp,AERALP,France
 ALT,Aerolíneas Centrales,AERLINEAS CENTRALES,Mexico
 ALU,Air Luxor STP,LUXORJET,São Tomé and Príncipe
 ALV,Aeropostal Alas de Venezuela,AEROPOSTAL,Venezuela
-ALW,Alas Nacionales, S.A.,ALNACIONAL,Dominican Republic
+ALW,Alas Nacionales S.A.,ALNACIONAL,Dominican Republic
 ALX,Hewa Bora Airways,ALLCONGO,Democratic Republic of the Congo
 ALY,Alyeska Air Service,ALYESKA,United States
 ALZ,Alta Flights (Charters) Ltd.,,Canada
@@ -242,7 +308,9 @@ AMC,Air Malta,AIR MALTA,Malta
 AMD,Garden City Helicopters,,New Zealand
 AME,Spanish Air Force,AIRMIL,Spain
 AMF,Ameriflight,AMFLIGHT,United States
+AMG,Air Minas Linhas A,,Brazil
 AMH,Alan Mann Helicopters Ltd.,MANN,United Kingdom
+AMI,Air Maldives,,Maldives
 AMJ,Aviation Amos,AVIATION AMOS,Canada
 AMK,Amerer Air,AMER AIR,Austria
 AML,Air Malawi,MALAWI,Malawi
@@ -253,13 +321,16 @@ AMP,Aero Transporte S.A. (ATSA),ATSA,Peru
 AMQ,Aeromedicare Ltd.,LIFELINE,United Kingdom
 AMR,Air Specialties Corporation,AIR AM,United States
 AMS,Air Muskoka,AIR MUSKOKA,Canada
+AMT,ATA Airlines,,United States
 AMU,Air Macau,AIR MACAO,Macao
 AMV,AMC Airlines,,Egypt
+AMW,Air Midwest,,United States
 AMX,Aeroméxico,AEROMEXICO,Mexico
 AMY,Air Ambar,AIR AMBAR,Dominican Republic
 AMZ,Amiya Airline,AMIYA AIR,Nigeria
 ANA,All Nippon Airways,ALL NIPPON,Japan
 ANB,Air Navigation And Trading Co. Ltd.,AIR NAV,United Kingdom
+ANC,Anglo Cargo,,United Kingdom
 AND,National Jet Service,AIR INDIANA,United States
 ANE,Air Nostrum,AIR NOSTRUM,Spain
 ANG,Air Niugini,NIUGINI,Papua New Guinea
@@ -270,83 +341,102 @@ ANL,Nacoia Lda,AIR NACOIA,Angola
 ANM,Aerotransportacion de Norteamerica,NORAM,Mexico
 ANO,Airnorth,TOPEND,Australia
 ANQ,Aerolínea de Antioquia,ANTIOQUIA,Colombia
+ANR,Yanair,YANAIR,Ukraine
 ANS,Andes Líneas Aéreas,AEROANDES,Argentina
 ANT,Air North Charter - Canada,AIR NORTH,Canada
+ANU,Andalus Lineas Aereas,,Spain
 ANV,Air Nevada,AIR NEVADA,United States
+ANW,Aviacion Del Noroeste,AVINOR,Mexico
 ANX,Secretaria de Marina,SECRETARIA DEMARINA,Mexico
 ANZ,Air New Zealand,NEW ZEALAND,New Zealand
-AOA,Alcon Servicios Aéreos, S.A. de C.V.,ALCON,Mexico
+AO1,AirOne Atlantic,,Slovakia
+AOA,Alcon Servicios Aéreos S.A. de C.V.,ALCON,Mexico
 AOB,Aerocaribe Coro,CARIBE CORO,Venezuela
 AOC,AVCOM,AERO AVCOM,Russia
 AOD,Aero Vodochody,AERO CZECH,Czech Republic
 AOE,Air One Executive,,Italy
 AOF,Atair Pty Ltd.,ATAIR,South Africa
+AOG,Aero VIP,,Argentina
+AOI,Astoria,ASTORIA,Canada
 AOJ,Avcon Jet,ASTERIX,Austria
+AOK,Aeroatlantico Colombia,,Colombia
+AOL,Angkor Airlines,,Cambodia
+AOM,AOM French Airlines,,France
 AON,Aero Entreprise,AERO ENTERPRISE,France
-AOO,As, Opened Joint Stock Company,COMPANY AS,Ukraine
+AOO,As Opened Joint Stock Company,COMPANY AS,Ukraine
 AOP,Aeropiloto,AEROPILOTO,Portugal
 AOR,Afro International Ent. Limited,INTER-AFRO,Nigeria
-AOS,Servicios Aéreos Del Sol, S.A. de C.V.,AEROSOL,Mexico
+AOS,Servicios Aéreos Del Sol S.A. de C.V.,AEROSOL,Mexico
 AOT,Asia Overnight Express,ASIA OVERNIGHT,Philippines
 AOU,Air Tractor,AIR TRACTOR,Croatia
 AOV,Aero Vision,AEROVISION,France
+AOW,Air Andaman (2Y),,Thailand
 AOX,Aerotaxi Del Valle,AEROVALLE,Colombia
 APA,Air Park Aviation Ltd.,CAN-AM,Canada
-APC,Airpac Airlines, Inc.,AIRPAC,United States
+APC,Airpac Airlines Inc.,AIRPAC,United States
 APD,Sabre Pacific,,Australia
 APE,Parcel Express,AIR PARCEL,United States
 APF,Amapola Flyg AB,AMAPOLA,Sweden
 APG,Air People International,AIR PEOPLE,Thailand
-APH,Alpha Aviation, Inc.,AIRFLIGHT,United States
-API,ASA Pesada, Lda.,ASA PESADA,Angola
+APH,Alpha Aviation Inc.,AIRFLIGHT,United States
+API,ASA Pesada Lda.,ASA PESADA,
 APJ,Peach Aviation,AIR PEACH,Japan
 APK,Air Peace,,New Zealand
-APL,Appalachian Flying Service, Inc.,APPALACHIAN,United States
-APM,Airpac, Inc.,ALASKA PACIFIC,United States
-APP,Aerolíneas Pacífico Atlántico, S.A. (Apair),AEROPERLAS,Panama
+APL,Appalachian Flying Service Inc.,APPALACHIAN,United States
+APM,Airpac Inc.,ALASKA PACIFIC,United States
+APO,Aeropro,,Canada
+APP,Aerolíneas Pacífico Atlántico S.A. (Apair),AEROPERLAS,Panama
 APQ,Aspen Aviation,ASPEN BASE,United States
 APR,Aerolíneas Primordiales,AEROPERLAS,Mexico
-APT,LAP Colombia - Líneas Aéreas Petroleras, S.A.,LAP,Colombia
-APU,Aeropuma, S.A.,AEROPUMA,El Salvador
+APT,LAP Colombia - Líneas Aéreas Petroleras S.A.,LAP,Colombia
+APU,Aeropuma S.A.,AEROPUMA,El Salvador
 APV,Air Plan International,AIR PLAN,Democratic Republic of the Congo
+APW,Arrow Air,,United States
 APX,Apex Air Cargo,PARCEL EXPRESS,United States
 APY,APA Internacional,APA INTERNACIONAL,Dominican Republic
-AQA,Aeroatlas, S.A.,ATCO,Colombia
+AQA,Aeroatlas S.A.,ATCO,Colombia
 AQL,Aquila Air Ltd.,AQUILA,Canada
+AQN,Air Queensland,,Australia
 AQO,Aluminum Company Of America,ALCOA SHUTTLE,United States
 AQS,Airstream,,United States
-AQT,Aviones de Renta de Quintana Roo, S.A. de C.V.,AVIOQUINTANA,Mexico
+AQT,Aviones de Renta de Quintana Roo S.A. de C.V.,AVIOQUINTANA,Mexico
+AQU,AirQuarius Aviation,,South Africa
 AQZ,Aerodyne Charter Company,QUANZA,United States
 ARA,Arik Air,ARIK AIR,Nigeria
 ARB,Avia Air N.V.,AVIAIR,Aruba
 ARC,Air Routing International Corp.,,United States
-ARE,Aires, Aerovías de Integración Regional, S.A.,AIRES,Colombia
+ARD,Aerocondor,,Portugal
+ARE,Aires Aerovías de Integración Regional S.A.,AIRES,Colombia
+ARF,Aero Flight,,Germany
 ARG,Aerolíneas Argentinas,ARGENTINA,Argentina
 ARH,Aerohelicopteros,AEROHELCA,Venezuela
 ARI,Aero Vics,AEROVICS,Mexico
-ARJ,Aerojet de Costa Rica, S.A.,,Costa Rica
+ARJ,Aerojet de Costa Rica S.A.,,Costa Rica
 ARK,Aero Link Air Services S.L.,LINK SERVICE,Spain
 ARL,Airlec - Air Aquitaine Transport,AIRLEC,France
+ARM,Aeromarket Express,,Spain
 ARO,Acero Taxi,ACERO,Mexico
 ARP,Aero Corporate,IVORYCORP,Côte d'Ivoire
-ARQ,Armstrong Air, Inc.,ARMSTRONG,Canada
+ARQ,Armstrong Air Inc.,ARMSTRONG,Canada
 ARR,Air Armenia,AIR ARMENIA,Armenia
 ARS,Aeromet Servicios,METSERVICE,Chile
 ART,Aerotal Aerolíneas Territoriales de Colombia Ltda.,AEROTAL,Colombia
 ARU,Aruba Airlines,ARUBA,Aruba
 ARV,Aravco Ltd.,ARAVCO,United Kingdom
 ARW,Aria,ARIABIRD,France
-ARX,Air Xpress, Inc.,AIREX,United States
+ARX,Air Xpress Inc.,AIREX,United States
 ARY,Argosy Airways,GOSEY,United States
 ARZ,Air Resorts,AIR RESORTS,United States
-ASA,Alaska Airlines, Inc.,ALASKA,United States
+ASA,Alaska Airlines Inc.,ALASKA,United States
 ASB,Air-Spray 1967 Ltd.,AIR SPRAY,Canada
 ASC,Air Star Corporation,AIR STAR,Canada
 ASD,Air Sinai,,Egypt
+ASE,Airstars,,Russia
 ASF,Austrian Air Force,AUSTRIAN AIRFORCE,Austria
 ASG,African Star Airways (PTY) Ltd.,AFRICAN STAR,South Africa
 ASH,Mesa Airlines,AIR SHUTTLE,United States
-ASI,Aerosun International, Inc.,AEROSUN,United States
+ASI,Aerosun International Inc.,AEROSUN,United States
+ASJ,AstonJet,,France
 ASK,Aerosky,MULTISKY,Spain
 ASL,Air Serbia,AIR SERBIA,Serbia
 ASM,Awesome Flight Services (PTY) Ltd.,AWESOME,South Africa
@@ -355,20 +445,25 @@ ASO,Aero Slovakia,AERO NITRA,Slovakia
 ASP,Airsprint,AIRSPRINT,Canada
 ASQ,Atlantic Southeast Airlines,ACEY,United States
 ASR,Aero Sotravia,SOTRAVIA,France
-ASS,Air Class, S.A. de C.V.,AIR CLASS,Mexico
+ASS,Air Class S.A. de C.V.,AIR CLASS,Mexico
 AST,Aerolíneas Del Oeste,AEROESTE,Mexico
+ASU,Compania Boliviana de Transporte Aereo Privado Aerosur,ASUR,Bolivia
 ASV,Air Seoul,AIR SEOUL,South Korea
+ASW,Air Southwest Ltd.,,Canada
 ASX,Air Special,AIRSPEC,Czech Republic
 ASY,Royal Australian Air Force,AUSSIE,Australia
+ASZ,Astrakhan Airlines,,Russia
 ATA,Air Transport Association,,United States
 ATB,Atlantair Ltd.,STARLITE,Canada
 ATC,Air Tanzania,TANZANIA,Tanzania
 ATD,Aerotours Dominicana,AEROTOURS,Dominican Republic
-ATE,Atlantis Transportation Services, Ltd.,ATLANTIS CANADA,Canada
+ATE,Atlantis Transportation Services Ltd.,ATLANTIS CANADA,Canada
 ATF,Compañía Aerotécnicas Fotográficas,AEROTECNICAS,Spain
 ATG,Aerotranscargo[6],MOLDCARGO,Moldova
 ATH,Air Travel Corp.,AIR TRAVEL,United States
+ATI,Aero-Tropics Air Services,,Australia
 ATJ,Air Traffic GmbH,SNOOPY,Germany
+ATK,AeroTACA,,Colombia
 ATL,Atlas Air Service,ATLAS,Germany
 ATM,Airlines of Tasmania,AIRTAS,Australia
 ATN,Air Transport International,AIR TRANSPORT,United States
@@ -381,54 +476,65 @@ ATU,Atlant Aerobatics Ltd.,ATLANT HUNGARY,Hungary
 ATV,Avanti Air,AVANTI AIR,Germany
 ATW,Air Antwerp,DEVIL,Belgium
 ATX,Warwickshire Aerocentre Ltd.,AIRTAX,United Kingdom
+ATY,Air Traffic Nairobi,AIRCARE,Kenya
 ATZ,Ace Air,ACE TAXI,South Korea
 AUA,Austrian Airlines,AUSTRIAN,Austria
-AUD,Audi Air, Inc.,AUDI AIR,United States
+AUB,Augsburg Airways,,Germany
+AUC,Transaustralian Air Express,,Australia
+AUD,Audi Air Inc.,AUDI AIR,United States
 AUF,Augusta Air Luftfahrtunternehmen,AUGUSTA,Germany
 AUH,Abu Dhabi Amiri Flight,SULTAN,United Arab Emirates
 AUI,Ukraine International Airlines,UKRAINE INTERNATIONAL,Ukraine
 AUJ,Business Flight Salzburg,AUSTROJET,Austria
+AUK,AUOS,,United Kingdom
 AUL,Nordavia,ARCHANGELSK AIR,Russia
 AUM,Air Atlantic Uruguay,ATLAMUR,Uruguay
 AUN,Aviones Unidos,AVIONES UNIDOS,Mexico
-AUO,Empresa (Aero Uruguay), S.A.,UNIFORM OSCAR,Uruguay
+AUO,Empresa (Aero Uruguay) S.A.,UNIFORM OSCAR,Uruguay
 AUP,Avia Business Group,,Russia
 AUR,Aurigny Air Services,AYLINE,United Kingdom
+AUS,Aus-Air,,Australia
 AUT,Austral Líneas Aéreas,AUSTRAL,Argentina
-AUU,Aurora Aviation, Inc.,AURORA AIR,United States
+AUU,Aurora Aviation Inc.,AURORA AIR,United States
 AUX,Air Uganda International Ltd.,,Uganda
-AUY,Aerolíneas Uruguayas, S.A.,AUSA,Uruguay
+AUY,Aerolíneas Uruguayas S.A.,AUSA,Uruguay
 AUZ,Australian Airlines,AUSTRALIAN,Australia
 AVA,Avianca,AVIANCA,Colombia
 AVB,Aviation Beauport,BEAUPAIR,United Kingdom
-AVD,Álamo Aviación, S.L.,ALAMO,Spain
+AVD,Álamo Aviación S.L.,ALAMO,Spain
+AVE,Avensa,,Venezuela
 AVF,Aviair Aviation Ltd.,CARIBOO,Canada
 AVG,Aviation Legacy,AVILEF,Gambia
 AVH,AV8 Helicopters,KENT HELI,United Kingdom
 AVJ,Avia Traffic Company,ATOMIC,Kyrgyzstan
 AVK,AV8 Helicopters,AVIATE-COPTER,South Africa
-AVM,Aviación Ejecutiva Mexicana, S.A.,AVEMEX,Mexico
+AVL,Aviation Adventures,SKY VENTURES,United States
+AVM,Aviación Ejecutiva Mexicana S.A.,AVEMEX,Mexico
 AVN,Air Vanuatu,AIR VAN,Vanuatu
 AVO,Aviation at Work,AVIATION WORK,South Africa
 AVP,Avcorp Registrations,AVCORP,United Kingdom
-AVQ,Aviation Services, Inc.,AQUILINE,United States
-AVR,Active Aero Charter, Inc.,ACTIVE AERO,United States
+AVQ,Aviation Services Inc.,AQUILINE,United States
+AVR,Active Aero Charter Inc.,ACTIVE AERO,United States
 AVS,Avialsa T-35,AVIALSA,Spain
+AVT,Asia Avia Airlines,,Indonesia
 AVU,Avia Sud Aérotaxi,AVIASUD,France
 AVV,Airvantage Incorporated,AIRVANTAGE,United States
 AVW,Aviator Airways,AVIATOR,Greece
 AVX,Aeroclub de Vitoria,,Spain
-AVY,Aerovaradero, S.A.,AEROVARADERO,Cuba
+AVY,Aerovaradero S.A.,AEROVARADERO,Cuba
 AVZ,Air Valencia,AIR VALENCIA,Spain
-AWB,Airways International, Inc.,AIRNAT,United States
+AWA,Asia Wings,,Kazakhstan
+AWB,Airways International Inc.,AIRNAT,United States
 AWC,Titan Airways,ZAP,United Kingdom
 AWD,Providence Aviation Services,,Pakistan
 AWE,America West Airlines,CACTUS,United States
 AWF,Aeroforward,,United States
+AWG,Animawings,ANIMA WINGS,Romania
 AWI,Air Wisconsin,WISCONSIN,United States
 AWJ,Sahel Airlines,SAHEL AIRLINES,Niger
 AWK,Airwork,AIRWORK,New Zealand
 AWL,Air Walser,,Malta
+AWM,Asian Wings Airways,,Burma
 AWN,Air Niamey,AIR NIAMEY,Niger
 AWO,Awood Air Ltd.,AWOOD AIR,Canada
 AWP,Aeroworld Pakistan,,Pakistan
@@ -437,55 +543,72 @@ AWR,Arctic Wings And Rotors Ltd.,ARCTIC WINGS,Canada
 AWS,Arab Wings,ARAB WINGS,Jordan
 AWT,Air West,AIR WEST,Canada
 AWU,Sylt Air GmbH,SYLT-AIR,Germany
-AWV,Airwave Transport, Inc.,AIRWAVE,Canada
+AWV,Airwave Transport Inc.,AIRWAVE,Canada
+AWW,Air Wales,,United Kingdom
 AWX,Civil Aviation Authority Directorate of Airspace Policy,ALLWEATHER,United Kingdom
-AWY,Aeroway, S.L.,AEROWEE,Spain
+AWY,Aeroway S.L.,AEROWEE,Spain
 AWZ,AirWest,,Sudan
 AXA,Avag Air,,Austria
 AXB,Air India Express,EXPRESS INDIA,India
+AXC,Indochina Airlines,,Vietnam
 AXD,Air Express,AIR SUDEX,Sudan
+AXE,Air Explore,,Slovakia
 AXF,Asian Express Airlines,FREIGHTEXPRESS,Australia
+AXG,Air X Charter GmbH & Co.KG,FORTUNE,Germany
 AXH,Aeromexhaga,AEROMEXHAGA,Mexico
-AXI,Aeron International Airlines, Inc.,AIR FREIGHTER,United States
+AXI,Aeron International Airlines Inc.,AIR FREIGHTER,United States
 AXK,African Express Airways,EXPRESS JET,Kenya
+AXL,Air Exel,,Netherlands
 AXM,AirAsia,RED CAP,Malaysia
+AXN,Alexandair,,Greece
 AXP,Aeromax,AEROMAX SPAIN,Spain
 AXQ,Action Airlines (Action Air Charter),ACTION AIR,United States
-AXR,Axel Rent, S.A.,RENTAXEL,Mexico
+AXR,Axel Rent S.A.,RENTAXEL,Mexico
 AXS,Altus Airlines,ALTUS,United States
+AXT,AX Transporter,AXTRANSPORTER,Mexico
 AXV,Aviaxess,AXAVIA,France
 AXX,Advance Air Luftfahrtgesellschaft,SKY SHUTTLE,Germany
 AXY,Air X Charter,LEGEND,Malta
+AXZ,Aereonautica militare,,Italy
 AYB,Belgian Army,BELGIAN ARMY,Belgium
+AYD,Aladia Airlines,,Mexico
 AYE,Yunnan Yingan Airlines,AIR YING AN,China
 AYG,Yangon Airways,AIR YANGON,Burma
 AYK,Aykavia Aircompany,,Armenia
-AYM,Airman, S.L.,AIRMAN,Spain
-AYN,Atlantic Airlines, S.A.,ATLANTIC NICARAGUA,Nicaragua
+AYM,Airman S.L.,AIRMAN,Spain
+AYN,Atlantic Airlines S.A.,ATLANTIC NICARAGUA,Nicaragua
 AYR,Flight Training Europe,CYGNET,Spain
 AYS,Awsaj Aviation Services,,Libya
 AYT,Ayeet Aviation & Tourism,AYEET,Israel
 AYU,Yuhi Air Lines,,Japan
 AYY,Air Alliance Express,,Germany
+AYZ,Atlant-Soyuz Airlines,,Russia
 AZA,Alitalia,ALITALIA,Italy
 AZB,Zaab Air,ZAAB AIR,Ghana
+AZD,Zimex Aviation Austria,MAILMAN,Austria
 AZE,Arcus-Air Logistic,ARCUS AIR,Germany
 AZF,Air Zermatt AG,AIR ZERMATT,Switzerland
 AZG,Silk Way West Airlines,SILK WEST,Azerbaijan
+AZH,SilkWay Helicopter Services,HELIAZE,Azerbaijan
 AZI,Astra Airlines,ASTRA,Greece
 AZJ,Zas Air,,Egypt
 AZK,Azalhelikopter,AZALHELICOPTER,Azerbaijan
+AZL,Africa One,,Zambia
 AZM,Aerocozumel,AEROCOZUMEL,Mexico
 AZN,Línea Aérea Amaszonas,,Bolivia
+AZO,Azimuth,AZIMUTH-DON,Russia
 AZP,Arizona Pacific Airways,ARIZONA PACIFIC,United States
 AZQ,Silk Way Airlines,SILK LINE,Azerbaijan
 AZR,Zenith Air,ZENAIR,South Africa
 AZS,Aviacon Zitotrans Air Company,ZITOTRANS,Russia
-AZT,Azimut, S.A.,AZIMUT,Spain
+AZT,Azimut S.A.,AZIMUT,Spain
 AZU,Azul Linhas Aéreas Brasileiras,Azul,Brazil
+AZV,Azov Avia Airlines,,Ukraine
 AZW,Air Zimbabwe,AIR ZIMBABWE,Zimbabwe
+AZX,Air Max Africa,,Gabon
 AZY,Aztec Worldwide Airlines,AZTEC WORLD,United States
 AZZ,Azza Transport,AZZA TRANSPORT,Sudan
+BA1,Baltic Air lines,,Latvia
 BAA,Balkan Agro Aviation,BALKAN AGRO,Bulgaria
 BAB,Bahrain Air BSC (Closed),AWAL,Bahrain
 BAC,BAC Leasing Limited,,United Kingdom
@@ -507,27 +630,34 @@ BAV,Bay Aviation Ltd,BAY AIR,Bangladesh
 BAW,British Airways,SPEEDBIRD,United Kingdom
 BAX,Best Aero Handling Ltd,,Russia
 BAY,Bravo Airways,,Ukraine
+BAZ,BAE Systems Flight Training,,Australia
 BBA,Bannert Air,BANAIR,Austria
 BBB,SwedJet Airways,BLACKBIRD,Sweden
 BBC,Biman Bangladesh Airlines,BANGLADESH,Bangladesh
 BBD,Bluebird Nordic,BLUE CARGO,Iceland
 BBE,Ababeel Aviation,BABEL AIR,Sudan
 BBF,B-Air Charter,SPEEDCHARTER,Germany
+BBG,Bluebird Airways (BZ),,Greece
 BBJ,Blue Air Lines,BLUE KOREA,South Korea
 BBL,IBM Euroflight Operations,BLUE,Switzerland
 BBN,Civil Aviation Authority Airworthiness Division,BRABAZON,United Kingdom
 BBO,Flybaboo,BABOO,Switzerland
 BBR,Santa Barbara Airlines,SANTA BARBARA,Venezuela
 BBS,Beibars CJSC,BEIBARS,Kazakhstan
+BBT,Air Bashkortostan,,Russia
 BBV,Bravo Airlines,BRAVO EUROPE,Spain
 BBW,BB Airways,BEEBEE AIRWAYS,Nepal
+BBX,Bel Air Aviation A/S,BLUEBEL,Denmark
+BBY,Blue Bird Aviation,YEMEN BLUE,Yemen
 BBZ,Bluebird Aviation,COBRA,Kenya
 BCB,Carib Express,WAVEBIRD,Barbados
+BCC,BusinessAir,,Thailand
 BCF,BACH Flugbetriebsges,BACH,Austria
 BCH,Phillips Air,BEACHBALL,United States
 BCI,Blue Islands,BLUE ISLAND,United Kingdom
 BCJ,Blue Jet Charters,BLUE BOY,Poland
 BCK,Priority Aviation Company,BANKCHECK,United States
+BCL,British Caribbean Airways,,United Kingdom
 BCN,Ocean Air,BLUE OCEAN,Mauritania
 BCR,British Charter,BACKER,United Kingdom
 BCS,European Air Transport,EUROTRANS,Belgium
@@ -537,6 +667,7 @@ BCY,CityJet,CITY JET,Ireland
 BDA,Blue Dart Aviation,BLUE DART,India
 BDF,Bissau Discovery Flying Club,BISSAU DISCOVERY,Guinea-Bissau
 BDG,Mississippi State University,BULLDOG,United States
+BDI,Benair,BIRDIE,Denmark
 BDM,Air Bandama,BANDAMA,Ivory Coast
 BDN,DERA Boscombe Down,GAUNTLET,United Kingdom
 BDR,Badr Airlines,BADR AIR,Sudan
@@ -550,11 +681,14 @@ BEF,Balear Express,BALEAR EXPRESS,Spain
 BEH,Bel Air Helicopters,BLUECOPTER,Denmark
 BEK,Berkut Air,BERKUT,Kazakhstan
 BEL,Brussels Airlines,BEE-LINE,Belgium
+BER,Air Berlin,,Germany
 BES,Aero Services Executive,BIRD EXPRESS,France
 BET,BETA - Brazilian Express Transportes Aéreos,BETA CARGO,Brazil
+BEU,Bateleur Air,,South Africa
 BEZ,Kingfisher Air Services,SEA BREEZE,United States
 BFA,Presidence Du Faso,,Burkina Faso
 BFC,Basler Flight Service,BASLER,United States
+BFD,Bertelsmann AG,MEDIA JET,Germany
 BFF,Air Baffin,AIR BAFFIN,Canada
 BFG,Bear Flight,BEARFLIGHT,Sweden
 BFL,Buffalo Airways,BUFFALO,Canada
@@ -563,7 +697,12 @@ BFO,Bombardier,BOMBARDIER,Canada
 BFR,Burkina Airlines,BURKLINES,Burkina Faso
 BFS,Business Flight Sweden,BUSINESS FLIGHT,Sweden
 BFW,Bahrain Defence Force,SUMMAN,Bahrain
+BFY,Bestfly,MWANGO BEST,AO
+BG1,BudgetAir,,Germany
 BGA,Airbus Transport International,BELUGA,France
+BGB,Big Bend Community College,BIG BEND,United States
+BGC,Good Jet,YANDU,China
+BGD,Air Bangladesh,,Bangladesh
 BGF,Aviodetachment-28,BULGARIAN,Bulgaria
 BGG,Aero BG,AERO BG,Mexico
 BGH,BH Air,BALKAN HOLIDAYS,Bulgaria
@@ -571,10 +710,13 @@ BGI,British Gulf International,BRITISH GULF,São Tomé and Príncipe
 BGK,British Gulf International-Fez,GULF INTER,Kyrgyzstan
 BGL,Benin Golf Air,BENIN GOLF,Benin
 BGM,Bugulma Air Enterprise,BUGAVIA,Russia
+BGN,Budget Lines,SKYBUDDY,TH
 BGR,Budget Air Bangladesh,BUDGET AIR,Bangladesh
 BGT,Bergen Air Transport,BERGEN AIR,Norway
+BGY,Bingo Airways,,Poland
 BHA,Buddha Air,BUDDHA AIR,Nepal
 BHC,Aerotaxis De La Bahia,BAHIA,Mexico
+BHD,Bangkok Helicopter Services,BANGKOK DUSIT,TH
 BHI,Balkh Airlines,SHARIF,Afghanistan
 BHK,Blu Halkin,BLUEHAKIN,United Kingdom
 BHL,Bristow Helicopters,BRISTOW,United Kingdom
@@ -586,8 +728,11 @@ BHS,Bahamasair,BAHAMAS,Bahamas
 BHT,Bright Air,BRIGHTAIR,Netherlands
 BHV,Specavia Air Company,AVIASPEC,Russia
 BHY,Bosphorus European Airways,BOSPHORUS,Turkey
+BIA,Bohlke International Airways,BOHLKE,VI
 BIB,Michelin Air Services,,France
+BIC,Alphaland Aviation,BALESIN,Philippines
 BID,Binair,BINAIR,Germany
+BIE,Air Mediterranee,,France
 BIG,Big Island Air,BIG ISLE,United States
 BIH,British International Helicopters,BRINTEL,United Kingdom
 BIL,Billund Air Center,BILAIR,Denmark
@@ -600,8 +745,10 @@ BIZ,Bizjet Ltd,BIZZ,United Kingdom
 BJA,Baja Air,BAJA AIR,Mexico
 BJC,Baltic Jet Aircompany,BALTIC JET,Latvia
 BJK,Atlantic Airlines,BLACKJACK,United States
+BJN,Beijing Airlines,AIR JINGHUA,China
 BJS,Business Jet Solutions,SOLUTION,United States
 BJT,ACM Aviation,BAY JET,United States
+BJU,Aerojet Ltd,JET EXPRESS,Ukraine
 BJV,Beijing Vistajet Aviation,BEIJING VISTA,China
 BKA,Bankair,BANKAIR,United States
 BKF,BF-Lento OY,BAKERFLIGHT,Finland
@@ -609,9 +756,13 @@ BKH,RAF Barkston Heath,,United Kingdom
 BKJ,Barken International,BARKEN JET,United States
 BKK,Blink,BLINKAIR,United Kingdom
 BKL,Aircompany Barcol,BARCOL,Russia
+BKM,Advisors Aviation LLC,CARDINAL,United States
+BKO,Briko Air Services,BRIKO,Trinidad and Tobago
 BKP,Bangkok Airways,BANGKOK AIR,Thailand
 BKR,Civil Air Patrol South Carolina Wing,BOX KAR,United States
+BKT,TAB Charters,BLACKTAIL,South Africa
 BKV,Bukovyna,BUKOVYNA,Ukraine
+BKY,Blue Sky America,,United States
 BLA,All Charter Limited,ALL CHARTER,United Kingdom
 BLB,Blue Bird Aviation,BLUEBIRD SUDAN,Sudan
 BLC,Bellesavia,BELLESAVIA,Belarus
@@ -626,6 +777,8 @@ BLK,Westcoast Energy,BLUE FLAME,Canada
 BLL,Baltic Airlines,BALTIC AIRLINES,Russia
 BLM,Blue Sky Airlines,BLUE ARMENIA,Armenia
 BLN,Bali International Air Service,BIAR,Indonesia
+BLO,Belogorie,BELOGORIE,Russia
+BLR,Atlantic Coast Airlines,,United States
 BLS,Bearskin Lake Air Service,BEARSKIN,Canada
 BLT,Baltic Aviation,BALTAIR,United States
 BLU,IMP Aviation Services,BLUENOSE,Canada
@@ -634,14 +787,19 @@ BLW,Wermlandsflyg AB,BLUESTAR,Sweden
 BLX,TUIfly Nordic,BLUESCAN,Sweden
 BLY,Starair,BLARNEY,Ireland
 BLZ,Aero Barloz,AEROLOZ,Mexico
+BMA,bmi,,United Kingdom
 BMD,British Medical Charter,BRITISH MEDICAL,United Kingdom
 BME,Briggs Marine Environmental Services,BRIGGS,United Kingdom
+BMG,Image Air Charter Ltd,BOOMERANG,CA
 BMH,Bristow Masayu Helicopters,MASAYU,Indonesia
+BMI,bmibaby,,United Kingdom
 BMJ,Bemidji Airlines,BEMIDJI,United States
 BMK,GST Aero Aircompany,MURAT,Kazakhstan
 BML,Bismillah Airlines,BISMILLAH,Bangladesh
+BMM,Atlas Blue,,Morocco
 BMN,Bowman Aviation,BOWMAN,United States
 BMR,BMI Regional,MIDLAND,United Kingdom
+BMS,Blue Air,BLUE MESSENGER,Romania
 BMV,Alatau Airlines,OLIGA,Kazakhstan
 BMW,BMW,BMW-FLIGHT,Germany
 BMX,Banco de Mexico,BANXICO,Mexico
@@ -650,23 +808,27 @@ BNB,Aero Banobras,AEROBANOBRAS,Mexico
 BNC,Sundance Air,BARNACLE AIR,United States
 BND,Bond Offshore Helicopters,BOND,United Kingdom
 BNE,Benina Air,BENINA AIR,Libya
+BNF,Braniff International Airways,,United States
 BNG,BN Group Limited,VECTIS,United Kingdom
 BNI,Alberni Airways,ALBERNI,Canada
 BNJ,Air Service Liège (ASL),JET BELGIUM,Belgium
 BNL,Blue Nile Ethiopia Trading,NILE TRADING,Ethiopia
+BNO,Babcock Scandinavian AirAmbulance,NORSE,Norway
 BNR,Bonair Aviation,BONAIR,Canada
 BNS,Bancstar - Valley National Corporation,BANCSTAR,United States
 BNT,Bentiu Air Transport,BENTIU AIR,Sudan
 BNV,Benane Aviation Corporation,BENANE,Mauritania
 BNW,British North West Airlines,BRITISH NORTH,United Kingdom
 BNX,LAI - Línea Aérea IAACA,AIR BARINAS,Venezuela
-BNZ,Aerolíneas Bonanza,AERO BONANZA,Mexico
+BNZ,Bonza,BONZA,Australia
 BOA,Boniair,KUMANOVO,Macedonia
 BOB,Backbone A/S,BACKBONE,Denmark
 BOC,Aerobona,AEROBONA,Mexico
 BOD,Bond Air Services,UGABOND,Uganda
 BOE,Boeing,BOEING,United States
 BOF,Bordaire,BORDAIR,Canada
+BOG,Live Oak Banking Company,BIRD DOG,United States
+BOH,Air Bohemia,BOHEMIA,Czech Republic
 BOI,Aboitiz Air,ABAIR,Philippines
 BOL,Transportes Aéreos Bolivianos,BOL,Bolivia
 BON,B&H Airlines,Air Bosna,Bosnia and Herzegovina
@@ -683,14 +845,18 @@ BPO,Bundespolizei-Fliegertruppe,PIROL,Germany
 BPS,Budapest Aircraft Services/Manx2,BASE,Hungary
 BPT,Bonus Aviation,BONUS,United Kingdom
 BPX,British Petroleum Exploration,,Colombia
+BQB,Buquebus Líneas Aéreas,,Uruguay
+BRA,Braathens,,Norway
 BRB,BRA-Transportes Aéreos,BRA-TRANSPAEREOS,Brazil
 BRD,Brock Air Services,BROCK AIR,Canada
 BRE,Breeze Ltd,AVIABREEZE,Ukraine
 BRF,Air Bravo,AIR BRAVO,Uganda
 BRG,Bering Air,BERING AIR,United States
+BRH,Star Air Cargo,BRIGHTSTAR,South Africa
 BRJ,Borajet,BORA JET,Turkey
 BRK,Briansk State Air Enterprise,BRIANSK-AVIA,Russia
 BRL,Air Brasd'or,BRASD'OR,Canada
+BRM,Air 500,,Canada
 BRN,Branson Airlines,BRANSON,United States
 BRO,2Excel Aviation,BROADSWORD,United Kingdom
 BRP,AeroBratsk,AEROBRA,Russia
@@ -699,12 +865,16 @@ BRR,Mountain Air Service,MOUNTAIN AIR,United States
 BRS,Brazilian Air Force,BRAZILIAN AIR FORCE,Brazil
 BRT,British Regional Airlines,BRITISH,United Kingdom
 BRU,Belavia Belarusian Airlines,BELARUS AVIA,Belarus
+BRV,Bravo Air Congo,,Democratic Republic of the Congo
 BRW,Bright Aviation Services,BRIGHT SERVICES,Bulgaria
 BRX,Buffalo Express Airlines,BUFF EXPRESS,United States
 BRY,Burundayavia,BURAIR,Kazakhstan
+BRZ,Samara Airlines,,Russia
+BSA,Black Stallion Airways,,United States
 BSB,Air Wings,ARBAS,Moldova
 BSC,Bistair - Fez,BIG SHOT,Kyrgyzstan
 BSD,Blue Star Airlines,AIRLINES STAR,Mexico
+BSH,Beijing Capital Helicopter General Aviation Svs,CAPITAL ROTOR,China
 BSI,Brasair Transportes Aéreos,BRASAIR,Brazil
 BSJ,Blue Swan Aviation,BLUE SWAN,United Kingdom
 BSK,Miami Air International,BISCAYNE,United States
@@ -716,12 +886,16 @@ BSR,Guine Bissaur Airlines,BISSAU AIRLINES,Guinea-Bissau
 BSS,Bissau Aero Transporte,BISSAU AIRSYSTEM,Guinea-Bissau
 BST,Best Air,TUNCA,Turkey
 BSW,Blue Sky Airways,SKY BLUE,Czech Republic
+BSX,Bassaka airlines,,Cambodia
 BSY,Big Sky Airlines,BIG SKY,United States
+BTA,ExpressJet,,United States
 BTC,BAL Bashkirian Airlines,BASHKIRIAN,Russia
 BTH,Baltijas Helicopters,BALTIJAS HELICOPTERS,Latvia
 BTI,Air Baltic,AIRBALTIC,Latvia
 BTK,Batik Air,BATIK,Indonesia
 BTL,Baltia Air Lines,BALTIA,United States
+BTM,Air Batumi,,Georgia
+BTN,Bhutan Airlines,BHUTAN AIR,Bhutan
 BTP,Veritair,NET RAIL,United Kingdom
 BTQ,Boutique Air,BOUTIQUE,United States
 BTR,Botir-Avia,BOTIR-AVIA,Kyrgyzstan
@@ -731,28 +905,38 @@ BTU,Rolls-Royce plc,ROLLS,United Kingdom
 BTV,Batavia Air,BATAVIA,Indonesia
 BTX,Volkswagen Air Service,,Germany
 BTZ,Bristow U.S.,BRISTOW,United States
+BUB,Air Bourbon,,Reunion
 BUC,Bulgarian Air Charter,BULGARIAN CHARTER,Bulgaria
 BUE,Orebro Aviation,BLUELIGHT,Sweden
 BUG,UVT Aero,,Russia
 BUL,Blue Airlines,BLUE AIRLINES,Democratic Republic of the Congo
 BUN,Buryat Airlines Aircompany,BURAL,Russia
+BUR,Air Bucharest,,Romania
+BUU,Baikotovitchestrian Airlines ,,American Samoa
 BUZ,Buzz Stansted,BUZZ,United Kingdom
 BVA,Buffalo Airways,BUFFALO AIR,United States
 BVC,Bulgarian Aeronautical Centre,BULGARIAN WINGS,Bulgaria
+BVG,BVG Viajes SA de CV,BEEVEEGEE VIAJES,Mexico
+BVL,Bul Air,BULGARY,Bulgaria
 BVN,Baron Aviation Services,SHOW-ME,United States
 BVR,ACM Air Charter,BAVARIAN,Germany
 BVT,Berjaya Air,BERJAYA,Malaysia
-BVU,Bellview Airlines, Sierra Leone,,Sierra Leone
+BVU,Bellview Airlines,,Sierra Leone
 BVV,Sparc Avia,SPARC,Russia
 BWA,Caribbean Airlines,CARIBBEAN AIRLINES,Trinidad and Tobago
 BWD,Bluewest Helicopters-Greenland,BLUEWEST,Denmark
+BWG,Blue Wings,,Germany
 BWI,Blue Wing Airlines,BLUE TAIL,Suriname
+BWJ,HK Bellawings,BELLAWING,Hong Kong
 BWL,British World Airlines,BRITWORLD,United Kingdom
 BWY,Fleet Requirements Air Direction Unit,BROADWAY,United Kingdom
 BXA,Bahrain Executive Air Services,BEXAIR,Bahrain
 BXH,Bar XH Air,PALLISER,Canada
 BXI,Brussels International Airlines,XENIA,Belgium
 BXJ,Brixtel Group,BRIXTEL JET,United States
+BXR,Redding Aero Enterprises,,United States
+BXS,Spantax S.A.,,Spain
+BXX,Badlands Aviation LLC,STRONGBOX,US
 BYA,Berry Aviation,BERRY,United States
 BYC,Cambodia Bayon Airlines,Bayon Air,Cambodia
 BYE,Bayu Indonesia Air,BAYU,Indonesia
@@ -764,11 +948,14 @@ BYT,Patriot Aviation Limited,BYTE,United Kingdom
 BZA,Bizair Fluggesellschaft,BERLIN BEAR,Germany
 BZD,Canadian Global Air Ambulance,BLIZZARD,Canada
 BZE,Zenith Aviation,ZENSTAR,United Kingdom
+BZF,Jet Aviation Business Jets,,United States
 BZH,Brit Air,BRITAIR,France
+BZL,Aero Brazil,,Brazil
 BZQ,Seneca College,STING,Canada
 BZS,Aero Biniza,BINIZA,Mexico
 BZY,Fresh Air Aviation,BREEZY,United States
 BZZ,Butane Buzzard Aviation Corporation,BUZZARD,United Kingdom
+CA1,CanXpress,,Canada
 CAA,Civil Aviation Authority of the Czech Republic,INSPECTOR,Czech Republic
 CAB,Chesapeake Air Service,CHESAPEAKE AIR,United States
 CAC,Conquest Airlines,CONQUEST AIR,United States
@@ -795,14 +982,17 @@ CAY,Cayman Airways,CAYMAN,Cayman Islands
 CAZ,Cat Aviation,EUROCAT,Switzerland
 CBA,Civil Aviation Inspectorate of the Czech Republic,CALIBRA,Czech Republic
 CBB,Cheboksary Airenterprise JSC,CHEBAIR,Russia
+CBC,Caribair,,Dominican Republic
 CBD,Lockheed Martin Aeronautics,CATBIRD,United States
 CBE,Aerovías Caribe,AEROCARIBE,Mexico
+CBF,China Northern Airlines,,China
+CBG,GX Airlines,,China
 CBH,Corporate Eagle Management Services,CLUB HOUSE,United States
 CBI,Cabi,CABI,Ukraine
 CBJ,Beijing Capital Airlines,CAPITAL JET,China
 CBL,Cumberland Airways (Nicholson Air Service),CUMBERLAND,United States
 CBM,Cherokee Express,BLUE MAX,United States
-CBN,Southern Illinois University as "Aviation Flight",CARBONDALE,United States
+CBN,Southern Illinois University Flight School,CARBONDALE,United States
 CBO,Aerotaxi del Cabo,TAXI CABO,Mexico
 CBR,Cabair College of Air Training,CABAIR,United Kingdom
 CBS,Air Columbus,AIR COLUMBUS,Ukraine
@@ -811,13 +1001,17 @@ CBV,Aereo Cabo,CABOAEREO,Mexico
 CBY,RAF Coningsby,TYPHOON,United Kingdom
 CCA,Air China,AIR CHINA,China
 CCB,Caricom Airways,DOLPHIN,Barbados
+CCC,CCML Airlines,,Colombia
+CCD,Dalian Airlines,XIANGJIAN,China
 CCE,Cairo Air Transport Company,,Egypt
 CCF,CCF Manager Airline,TOMCAT,Germany
+CCG,Central Connect Airlines,,Czech Republic
 CCH,Chilchota Taxi Aéreo,CHILCHOTA,Mexico
 CCI,Capital Cargo International Airlines,CAPPY,United States
 CCK,Flight Trac,CABLE CHECK,United States
 CCL,Cambodia Airlines,ANGKOR WAT,Cambodia
 CCM,Air Corsica,CORSICA,France
+CCO,China Air Cargo,AVIC CARGO,China
 CCP,Champion Air,CHAMPION AIR,United States
 CCQ,Capital City Air Carriers,CAP CITY,United States
 CCT,Connect Air,CONNECT,Canada
@@ -833,12 +1027,14 @@ CDI,Cards Air Services,CARDS,Philippines
 CDL,Sunbird Airlines,CAROLINA,United States
 CDM,Carga Aérea Dominicana,CARGA AEREA,Dominican Republic
 CDN,Canadian Helicopters,CANADIAN,Canada
+CDO,Tchadia Airlines,TCHADIA,Chad
 CDP,Aero Condor Peru,CONDOR-PERU,Peru
 CDR,Canadian Regional Airlines,CANADIAN REGIONAL,Canada
 CDS,Spectrem Air,SPECDAS,South Africa
 CDT,Real Aero Club de Reus-Costa Dorado,AEROREUS,Spain
 CDU,Aerotrans,,Russia
 CDV,Airline Skol,SKOL,Russia
+CDX,Cedar Executive,CEDAREX,Lebanon
 CDY,Heliaviation Limited,CADDY,United Kingdom
 CEA,RegionsAir,CORP-X,United States
 CEB,Cebu Pacific,CEBU,Philippines
@@ -847,13 +1043,17 @@ CED,CEDTA (Compañía Ecuatoriana De Transportes Aéreos),CEDTA,Ecuador
 CEE,Servicios Aéreos Centrales,CENTRA AEREOS,Mexico
 CEF,Czech Air Force,CZECH AIR FORCE,Czech Republic
 CEG,Cega Aviation,CEGA,United Kingdom
+CEH,Central Helicopter Service,,Japan
+CEL,CEIBA Intercontinental,,Equatorial Guinea
 CEM,Central Mongolia Airways,CENTRAL MONGOLIA,Mongolia
+CEO,Comfort Express Virtual Charters,,United States
 CEP,Chipola Aviation,CHIPOLA,United States
 CER,Cetraca Aviation Service,CETRACA,Democratic Republic of the Congo
 CES,China Eastern Airlines,CHINA EASTERN,China
 CET,Centrafrican Airlines,CENTRAFRICAIN,Central African Republic
 CEV,Centre d'Essais en Vol,CENTEV,France
 CEX,Capitol Air Express,CAPITOL EXPRESS,United States
+CEY,Air Century,,Dominican Republic
 CFA,China Flying Dragon Aviation,FEILONG,China
 CFB,Chongqing Forebase General Aviation,FOREBASE,China
 CFC,Canadian Forces,CANFORCE,Canada
@@ -867,7 +1067,10 @@ CFJ,Fujian Airlines,FUJIAN,China
 CFL,Swedish Airlines,SWEDISH,Sweden
 CFM,ACEF,ACEF,Portugal
 CFN,RAF Church Fenton,CHURCH FENTON,United Kingdom
+CFP,Compania de Aviacion Faucett,,Peru
+CFR,Africa One,,Democratic Republic of the Congo
 CFS,Empire Airlines,EMPIRE AIR,United States
+CFT,Jet Freighters,,United States
 CFU,United Kingdom Civil Aviation Authority,MINAIR,United Kingdom
 CFV,Aero Calafia,CALAFIA,Mexico
 CFZ,Zhongfei General Aviation,ZHONGFEI,China
@@ -876,9 +1079,9 @@ CGB,Air Cargo Belize,CARGO BELIZE,Belize
 CGC,Cal Gulf Aviation,CAL-GULF,São Tomé and Príncipe
 CGD,Charlotte Air National Guard,,United States
 CGE,Nelson Aviation College,COLLEGE,New Zealand
+CGF,Cargo Air,CLEVER,Bulgaria
 CGG,Walmart Aviation,CHARGE,United States
 CGH,Guizhou Airlines,GUIZHOU,China
-CGI,Rusair JSAC,CGI-RUSAIR,Russia
 CGK,Click Airways,CLICK AIR,Kyrgyzstan
 CGL,Seagle Air,SEAGLE,Slovakia
 CGM,Cargoman,HOTEL CHARLIE,Oman
@@ -889,8 +1092,10 @@ CGR,Compagnia Generale Ripreseaeree,COMPRIP,Italy
 CGS,Centre of Applied Geodynamica,GEO CENTRE,Russia
 CGU,Chinguetti Airlines,CHINGUETTI,Mauritania
 CGV,Aero Clube Do Algarve,CLUBE ALGARVE,Portugal
+CGW,Air Great Wall,,China
 CGX,United States Coast Guard Auxiliary,COASTGUARD AUXAIR,United States
 CGY,Corporacion Paraguaya De Aeronautica,,Paraguay
+CGZ,Colorful Guizhou Airlines,COLORFUL,China
 CHA,Central Flying Service,CHARTER CENTRAL,United States
 CHB,West Air (China),WEST CHINA,China
 CHC,China Ocean Helicopter Corporation,CHINA HELICOPTER,China
@@ -918,18 +1123,25 @@ CHZ,Cherline,CHERL,Russia
 CIA,Civil Aviation Authority,CALIMERA,Slovakia
 CIB,Condor,CONDOR BERLIN,Germany
 CIC,ICC Canada,AIR TRADER,Canada
+CID,Asia Continental Airlines,,Kazakhstan
 CIE,Czech Government Flying Service,CZECH REPUBLIC,Czech Republic
+CIF,CB Airways UK ( Interliging Flights ),,United Kingdom
 CIG,Sirius-Aero,SIRIUS AERO,Russia
 CII,Cityfly,CITYFLY,Italy
+CIJ,C&I Corporation,NIKOLAUS,Romania
+CIK,Country International Airlines,,Kyrgyzstan
 CIL,Cecil Aviation,CECIL,United Kingdom
 CIM,Cimber Sterling,CIMBER,Denmark
 CIN,Cinnamon Air,CINNAMON,Sri Lanka
 CIO,Il Ciocco International Travel Service,CIOCCO,Italy
+CIP,City-Air Germany,,Germany
 CIR,Arctic Circle Air Service,AIR ARCTIC,United States
+CIS,Cat Island Air,CAT ISLAND,Bahamas
 CIT,Zanesville Aviation,ZANE,United States
 CIU,Cielos Airlines,CIELOS,Peru
 CIV,Civil Aviation Authority of New Zealand,CIVAIR,New Zealand
 CIW,Civair Airways,CIVFLIGHT,South Africa
+CIX,City Connexion Airlines,,Burundi
 CJA,CanJet,CANJET,Canada
 CJC,Colgan Air,COLGAN,United States
 CJE,Aeroservices Corporate,BIRD JET,France
@@ -938,6 +1150,7 @@ CJI,Corporate Jets,SEA JET,United States
 CJR,Caverton Helicopters,CAVERTON AIR,Nigeria
 CJS,Commonwealth Jet Service,COMMONWEALTH,United States
 CJT,Cargojet Airways,CARGOJET,Canada
+CJX,Jiangxi Air,AIR CRANE,China
 CJZ,Caliber Jet,CALIBER JET,United States
 CKA,Cook Inlet Aviation,COOK-AIR,United States
 CKC,CKC Services,,United States
@@ -955,10 +1168,12 @@ CLF,Bristol Flying Centre,CLIFTON,United Kingdom
 CLG,Chalair Aviation,CHALLAIR,France
 CLH,Lufthansa CityLine,HANSALINE,Germany
 CLI,Clickair,CLICKJET,Spain
+CLJ,Cello Aviation,,United Kingdom
 CLK,Clark Aviation,CLARKAIR,United States
 CLL,Aerovías Castillo,AEROCASTILLO,Mexico
 CLM,Cargo Link (Caribbean),CARGO LINK,Barbados
 CLN,Barnes Olsen Aeroleasing,SEELINE,United Kingdom
+CLO,Challenge Aero,,Ukraine
 CLP,Aero Club De Portugal,CLUB PORTUGAL,Portugal
 CLR,Trans America,CLINTON AIRWAYS,United States
 CLS,Challenge Air Transport,AIRISTO,Germany
@@ -990,10 +1205,12 @@ CMV,Calima Aviación,CALIMA,Spain
 CMX,El Caminante Taxi Aéreo,EL CAMINANTE,Mexico
 CMY,Cape Smythe Air,CAPE SMYTHE AIR,United States
 CMZ,CM Stair,CEE-EM STAIRS,Mauritania
+CNA,Centavia,,Serbia
 CNB,Cityline Hungary,CITYHUN,Hungary
 CNC,Corporación Aéreo Cencor,CENCOR,Mexico
 CND,Corendon Dutch Airlines,DUTCH CORENDON,Netherlands
 CNE,Air Toronto,CONNECTOR,Canada
+CNF,Canaryfly,,Spain
 CNG,Coastal Airways,SID-AIR,United States
 CNH,Aquila Air,CHENANGO,United States
 CNI,Empresa Nacional De Servicios Aéreos,SERAER,Cuba
@@ -1001,6 +1218,7 @@ CNJ,Nanjing Airlines,NINGHANG,China
 CNK,Sunwest Home Aviation,CHINOOK,Canada
 CNL,Centennial Airlines,WYO-AIR,United States
 CNM,Air China Inner Mongolia,MENGYUAN,China
+CNN,Canadian World,,Canada
 CNO,SAS Braathens,SCANOR,Norway
 CNR,Condor Aero Services,CONAERO,United States
 CNS,Cobalt Air,CHRONOS,United States
@@ -1008,9 +1226,12 @@ CNT,Centre national d'études des télécommunications - C.N.E.T.,KNET,France
 CNU,Air Consul,AIR CONSUL,Spain
 CNV,U.S. Navy Reserve Logistic Air Forces,CONVOY,United States
 CNW,Continental Airways,,Moldovoa
+CNX,Allcanada Express,,Canada
 CNY,Central Airways,CENTRAL LEONE,Sierra Leone
 COA,Continental Airlines,CONTINENTAL,United States
+COB,Cotair,COBRA JET,Benin
 COD,Concordavia,CONCORDAVIA,Ukraine
+COE,Comtel Air,,Austria
 COF,Confort Air,CONFORT,Canada
 COH,RAF Coltishall,COLT,United Kingdom
 COL,SC Aviation,,United States
@@ -1027,6 +1248,7 @@ CPA,Cathay Pacific,CATHAY,Hong Kong
 CPB,Corpac Canada,PENTA,Canada
 CPC,Canadian Pacific Airlines,EMPRESS,Canada
 CPD,Capital Airlines,CAPITAL DELTA,Kenya
+CPF,ATS Private Company,,Ukraine
 CPG,Corporacion Aeroangeles,CORPORANG,Mexico
 CPH,Champagne Airlines,CHAMPAGNE,France
 CPI,Compagnia Aeronautica Italiana,AIRCAI,Italy
@@ -1045,9 +1267,12 @@ CPZ,Compass Airlines,COMPASS ROSE,United States
 CQC,Central Queensland Aviation College,,Australia
 CQH,Spring Airlines,AIR SPRING,China
 CQN,Chongqing Airlines,CHONG QING,China
+CR1,Regionalia Chile,,Chile
+CR7,Sky Wing Pacific,,South Korea
 CRA,Coronado Aerolíneas,CORAL,Colombia
 CRB,Caricom Airways,CARIBBEAN COMMUTER,Suriname
 CRC,Cameroon Airlines Corporation,CAMAIRCO,Cameroon
+CRD,Air Corridor,,Mozambique
 CRE,Cree Airways,CREE AIR,Canada
 CRF,Croix Rouge Francais,CROIX ROUGE,France
 CRG,Cargoitalia,WHITE PELICAN,Italy
@@ -1060,17 +1285,21 @@ CRN,Carson Air Ltd,CARSON,CANADA
 CRO,Crown Airways,CROWN AIRWAYS,United States
 CRP,Aerotransportes Corporativos,AEROTRANSCORP,Mexico
 CRQ,Air Creebec,CREE,Canada
+CRR,Carranza,,Chile
 CRS,Comercial Aérea,COMERCIAL AEREA,Mexico
 CRT,Caribintair,CARIBINTAIR,Haiti
 CRV,Acropolis Aviation,ACROPOLIS,United Kingdom
 CRW,Crownair,REGAL,Canada
 CRX,Cross Aviation,CROSSAIR,United Kingdom
 CRY,Primavia Limited,CARRIERS,United Kingdom
+CRZ,Cruzeiro do Sul Servicos Aereos,,Brazil
 CSA,Czech Airlines,CSA,Czech Republic
+CSB,21 Air,CARGO SOUTH,United States
 CSC,Sichuan Airlines,SI CHUAN,China
 CSD,Courier Services,DELIVERY,United States
 CSE,CSE Aviation,OXFORD,United Kingdom
 CSF,Clasair,CALEDONIAN,United Kingdom
+CSG,China Southern Airlines Cargo,SOUTHERN CARGO,China
 CSH,Shanghai Airlines,SHANGHAI AIR,China
 CSI,Central Skyport,SKYPORT,United States
 CSJ,Castle Aviation,CASTLE,United States
@@ -1095,6 +1324,7 @@ CTE,Air Tenglong,TENGLONG,China
 CTF,Cutter Aviation,CUTTER FLIGHT,United States
 CTG,Canadian Coast Guard,CANADIAN COAST GUARD,Canada
 CTH,China General Aviation Corporation,TONGHANG,China
+CTJ,Tianjin Air Cargo,TIANJIN CARGO,China
 CTK,East Midlands Helicopters,COSTOCK,United Kingdom
 CTL,Central Airlines,CENTRAL COMMUTER,United States
 CTM,Commandement Du Transport Aerien Militaire Francais,COTAM,France
@@ -1111,9 +1341,11 @@ CTY,Cryderman Air Service,CENTURY,United States
 CTZ,CATA Línea Aérea,CATA,Argentina
 CUA,China United Airlines,LIANHANG,China
 CUB,Cubana de Aviación,CUBANA,Cuba
+CUD,Air Cudlua,,United Kingdom
 CUH,Urumqi Airlines,LOULAN,China
 CUI,Cancun Air,CAN-AIR,Mexico
 CUK,Polo Aviation,CHUKKA,United Kingdom
+CUL,Coulson Aviation Inc,COULSON,United States
 CUO,Aerocuahonte,CUAHONTE,Mexico
 CUT,Court Helicopters,COURT AIR,South Africa
 CVA,Air Chathams,CHATHAM,New Zealand
@@ -1121,10 +1353,12 @@ CVC,Centre-Avia,AVIACENTRE,Russia
 CVE,Cabo Verde Express,KABEX,Cape Verde
 CVF,Dassault Falcon Jet Corporation,CLOVERLEAF,United States
 CVG,Carill Aviation,CARILL,United Kingdom
+CVJ,Comercializacion de Aviacion Ejecutiva SA de CV,COMEREJECUTIVA,Mexico
 CVK,CAVOK Airlines,CARGO LINE,Ukraine
 CVL,Coval Air,COVAL,Canada
 CVO,Center Vol,CENTERVOL,Spain
 CVR,Chevron U.S.A,CHEVRON,United States
+CVS,Convers Avia Airline,CONVERS,RU
 CVT,Peran,CVETA,Kazakhstan
 CVU,Grand Canyon Airlines,CANYON VIEW,United States
 CVV,Comeravia,COMERAVIA,Venezuela
@@ -1140,33 +1374,41 @@ CWM,Air Marshall Islands,AIR MARSHALLS,Marshall Islands
 CWN,Cardiff Wales Flying Club,CAMBRIAN,United Kingdom
 CWP,Australian Customs Service,COASTWATCH,Australia
 CWR,Beijing City International Jet,CITY WORLD,China
+CWS,California Western,,United States
 CWT,Texas Airways,TEXAS AIRWAYS,United States
 CWU,Wuhan Airlines,WUHAN AIR,China
 CWW,Canair,CANAIR,China
 CWX,Crow Executive Air,CROW EXPRESS,United States
 CWY,Woodgate Aviation,CAUSEWAY,United Kingdom
 CWZ,Capitol Wings Airline,CAPWINGS,United States
+CX0,Copenhagen Express,,Denmark
 CXA,Xiamen Airlines,XIAMEN AIR,China
+CXB,Comlux Aruba,STARLUX,Aruba
 CXE,Caicos Express Airways,CAICOS,Turks and Caicos Islands
 CXH,China Xinhua Airlines,XINHUA,China
 CXI,Shanxi Airlines,SHANXI,China
 CXJ,Xinjiang Airlines,XINJIANG,China
+CXN,China Southwest Airlines,,China
 CXO,Conroe Aviation Services,CONROE AIR,United States
 CXP,Xtra Airways,CASINO EXPRESS,United States
 CXS,Boston-Maine Airways,CLIPPER CONNECTION,United States
+CXT,Coastal Air Transport,COASTAL,U.S. Virgin Islands
 CYA,Cheyenne Airways,CHEYENNE AIR,United States
 CYC,Cyprair Tours,CYPRAIR,Cyprus
+CYD,Access Air,,United States
 CYE,Aerocheyenne,AEROCHEYENNE,Mexico
 CYF,Company Flight,COMPANY FLIGHT,Denmark
 CYG,Yana Airlines,VICAIR,Cambodia
 CYH,China Southern Airlines Henan,YUHAO,China
 CYL,Air One Cityliner,CITYLINER,Italy
+CYM,Compass Airlines (Australia),,Australia
 CYN,Zhongyuan Aviation,ZHONGYUAN,China
 CYO,Air Transport,COYOTE,United States
 CYP,Cyprus Airways,CYPRUS,Cyprus
 CYS,Cypress Airlines,SKYBIRD,Canada
 CYT,Crystal Shamrock Airlines,CRYSTAL-AIR,United States
 CYZ,China Postal Airlines,CHINA POST,China
+CZV,Via Conectia Airlines,,Uruguay
 DAA,Decatur Aviation,DECUR,United States
 DAB,Dassault Aviation,,France
 DAC,McDonnell Douglas,DACO,United States
@@ -1175,12 +1417,15 @@ DAE,DHL Aero Expreso,YELLOW,Panama
 DAF,Danish Air Force,DANISH AIRFORCE,Denmark
 DAG,Dagestan Airlines,DAGAL,Russia
 DAH,Air Algérie,AIR ALGERIE,Algeria
+DAK,First Flying,,Japan
 DAL,Delta Air Lines,DELTA,United States
 DAM,Kyrgyzstan Department of Aviation,FLIGHT RESCUE,Kyrgyzstan
+DAN,Dan-Air London,,United Kingdom
 DAO,Daallo Airlines,DALO AIRLINES,Djibouti
 DAP,Aerovías DAP,DAP,Chile
 DAR,Danish Army,DANISH ARMY,Denmark
 DAS,Damascene Airways,AIRDAM,Syrian Arab Republic
+DAT,Brussels Airlines,,Belgium
 DAU,Dauair,DAUAIR,Germany
 DAV,Dornier Aviation Nigeria,DANA AIR,Nigeria
 DAY,Daya Aviation,DAYA,Sri Lanka
@@ -1190,8 +1435,10 @@ DBD,Air Niagara Express,AIR NIAGARA,Canada
 DBJ,Duchess of Britany (Jersey) Limited,DUCHESS,United Kingdom
 DBK,Dubrovnik Air,SEAGULL,Croatia
 DBR,Dutchbird,DUTCHBIRD,Netherlands
+DC2,Dense Connection,,United States
 DCA,Dreamcatcher Airways,DREAM CATCHER,United Kingdom
 DCC,Caribbean Air Cargo,CARICARGO,Barbados
+DCD,Air 26,,Angola
 DCE,Dutch Caribbean Express,DUTCH CARIBBEAN,Netherlands Antilles
 DCF,Aeropartner,,Czech Republic
 DCL,Transportes Aéreos Don Carlos,DON CARLOS,Chile
@@ -1209,11 +1456,16 @@ DEE,Dixie Airways,TACAIR,United States
 DEF,Aviation Defense Service,TIRPA,France
 DEG,Air Service Groningen,DEGGER,Netherlands
 DEI,Ecoair,,Algeria
+DEJ,Dana Executive Jets,,United Arab Emirates
+DEK,AviaStar Air Company,DEK AERO,Belarus
 DEL,Carib Aviation,RED TAIL,Antigua and Barbuda
+DER,Deer Jet,,China
 DES,Chilcotin Caribou Aviation,CHILCOTIN,Canada
 DET,DETA Air,SAMAL,Kazakhstan
 DEV,Red Devils Parachute Display Team,RED DEVILS,United Kingdom
 DFA,Aero Coach Aviation,AERO COACH,United States
+DFC,Aeropartner,DARK BLUE,Czech Republic
+DFL,Babcock AirAmbulance,MEDIFLIGHT,Sweden
 DFS,Dwyer Aircraft Services,DWYAIR,United States
 DGA,Yellow River Delta General Aviation,YELLOW RIVER,China
 DGO,DGO Jet,DGO JET,Mexico
@@ -1222,6 +1474,7 @@ DGX,Dasnair,DASNA,Switzerland
 DHA,Dahla Airlines,,Democratic Republic of Congo
 DHC,De Havilland,DEHAVILLAND,Canada
 DHE,DAP Helicopteros,HELIDAP,Chile
+DHI,Adam Air,,Indonesia
 DHK,DHL Air Limited,WORLD EXPRESS,United Kingdom
 DHL,Astar Air Cargo,D-H-L,United States
 DHM,Archer Aviation,ARCHER,United Kingdom
@@ -1229,16 +1482,22 @@ DHV,DHL Aviation,WORLDSTAR,South Africa
 DHX,DHL International,DILMUN,Bahrain
 DIA,Direct Air,BLUE SKY,United States
 DIC,Aeromedica,AEROMEDICA,Mexico
+DIG,DAC International Airlines,DAC AIR,GH
 DIN,Aerodin,AERODIN,Mexico
 DIP,Diplomatic Freight Services,DIPFREIGHT,United Kingdom
 DIR,Dirgantara Air Service,DIRGANTARA,Indonesia
 DIS,Di Air,DI AIR,Serbia
 DIX,Dix Aviation,DIX FLIGHT,Germany
+DJA,Antinea Airlines,,Algeria
+DJB,Djibouti Airlines,,Djibouti
 DJE,Durango Jet,DURANGO JET,Mexico
 DJR,Desert Jet,DESERT FLIGHT,United States
 DJS,DayJet,DAYJET,United States
 DJT,Dreamjet,DREAMJET,France
+DJU,Air Djibouti,,Djibouti
 DKA,Daka,,Kazakhstan
+DKE,Jubilee Airways,,United Kingdom
+DKH,Juneyao Airlines,,China
 DKN,Deccan Charters,DECCAN,India
 DKT,Sioux Falls Aviation,DAKOTA,United States
 DKY,Servicios Aéreos Elite,DAKOY,Spain
@@ -1249,12 +1508,18 @@ DLI,Delta Express International,DELTA EXPRESS,Ukraine
 DLK,Millennium Airlines,DEKKANLANKA,Sri Lanka
 DLR,Dala Air Services,DALA AIR,Nigeria
 DLS,Aero Modelo,AEROMODELO,Mexico
+DLT,Deutsche Luftverkehrsgesellschaft,,Germany
+DLU,Aerolineas Del Sur,,Chile
+DLX,Dreamline Aviation LLC,DREAMLINE,United States
+DLY,Air Independence,DAILY,DE
 DMC,Aerodinamica de Monterrey,DINAMICAMONT,Mexico
 DMD,Namdeb Diamond Corporation,DIAMONDJET,Namibia
+DME,Royal Flight,,Russia
 DMF,DMCFLY,DEMLY,Mexico
 DMI,Aeroservicios Dinamicos,AERODINAMICO,Mexico
 DMJ,Aerolíneas Damojh,DAMOJH,Mexico
 DML,Aerotaxis Dosmil,,Mexico
+DMO,Domodedovo Airlines,,Russia
 DNA,Aerodespachos de El Salvador,AERODESPACHOS,El Salvador
 DNC,Aerodynamics Málaga,FLYINGOLIVE,Spain
 DND,Eldinder Aviation,DINDER,Sudan
@@ -1262,14 +1527,18 @@ DNI,Servicios Aéreos Denim,AERO DENIM,Mexico
 DNJ,Aerodynamics Incorporated,DYNAJET,United States
 DNK,D&K Aviation,DIRECT JET,United States
 DNL,Dutch Antilles Express,DUTCH ANTILLES,Netherlands Antilles
+DNM,Denim Air,,Netherlands
 DNR,Dynamair Aviation,DYNAMAIR,Canada
 DNS,Dniproaviaservis Company,,Ukraine
 DNU,Danu Oro Transportas,DANU,Lithuania
 DNV,Donavia,DONAVIA,Russia
 DNY,Danish Navy,DANISH NAVY,Denmark
+DOA,Dominicana de Aviaci,,Dominican Republic
+DOB,Dobrolet,,Russia
 DOC,Norsk Luftambulanse,HELIDOC,Norway
 DOD,USAF Air Mobility Operations Control Center,,United States
 DOI,U.S. Department of the Interior,INTERIOR,United States
+DOJ,Justice Prisoner and Alien Transportation System,,United States
 DOM,Dos Mundos,DOS MUNDOS,Dominican Republic
 DON,Donair Flying Club,DONAIR,United Kingdom
 DOP,Dancopter,DANCOPTER,Denmark
@@ -1278,6 +1547,7 @@ DOT,Telnic Limited,DOT TEL,United Kingdom
 DOW,Best Jets Intl,DOWNTOWN,United States
 DPJ,Delta Private Jets,JET CARD,United States
 DPL,Dome Petroleum,DOME,Canada
+DPS,Alabama Law Enforcement Agency,BLUE-GRAY,United States
 DQA,Island Aviation Services,,Maldives
 DRB,Didier Rousset Buy,DIDIER,Chile
 DRC,Triton Airlines,TRITON AIR,Canada
@@ -1293,6 +1563,7 @@ DRT,Darta,DARTA,France
 DRU,Alrosa Air Company,MIRNY,Russia
 DRX,Des R Cargo Express,,Mauritania
 DRY,Deraya Air Taxi,DERAYA,Indonesia
+DRZ,PT Derazona Air Service,DERAZONA,Indonesia
 DSA,Danbury Airways,DANBURY AIRWAYS,United States
 DSC,Addis Air Cargo Services,ADDIS CARGO,Ethiopia
 DSH,Dash Air Charter,DASH CHARTER,United States
@@ -1305,9 +1576,12 @@ DSQ,Dasab Airlines,DASAB AIR,Uganda
 DSR,DAS Air Cargo,DAIRAIR,Uganda
 DST,Aex Air,DESERT,United States
 DSU,Delta State University,DELTA STATE,United States
+DSV,Direct Aero Services,,Romania
+DSY,Dennis Sky,,Israel
 DTA,TAAG Angola Airlines,DTA,Angola
 DTH,Tassili Airlines,TASSILI AIR,Algeria
 DTN,Data International,DATA AIR,Sudan
+DTO,Aerodesierto,AERODESIERTO,CL
 DTR,DAT Danish Air Transport,DANISH,Denmark
 DTV,Centre Airlines,DUTCH VALLEY,United States
 DTY,Destiny Air Services,DESTINY,Sierra Leone
@@ -1319,15 +1593,21 @@ DVA,Discovery Airways,DISCOVERY AIRWAYS,United States
 DVB,Don Avia,DONSEBAI,Kazakhstan
 DVI,Aero Davinci International,AERO DAVINCI,Mexico
 DVN,Adventia,,Spain
+DVY,Legends Airways,DEVIL RAY,United States
+DWA,Dense Airways,,United States
+DWD,Deutsche Luftverkehrsgesellschaft (DLT),,Germany
 DWN,Dawn Air,DAWN AIR,United States
 DWR,Delaware Skyways,DELAWARE,United States
 DWT,Darwin Airline,DARWIN,Switzerland
+DWW,Jet Courier Service,,United States
 DXH,East Star Airlines,EAST STAR,China
 DXP,Dallas Express Airlines,DALLAS EXPRESS,United States
+DXT,Dexter (DXT),,Russia
 DYA,Dynamic Airways,DYNAMIC AIR,United States
 DYE,Dynamic Air,DYNAMIC,Netherlands
 DYN,Aero Dynamics,AERO DYNAMIC,United States
 DZR,Midwest Aviation,DOZER,United States
+EAA,Eastok Avia,,Kyrgyzstan
 EAB,Swiss Eagle,SWISS EAGLE,Switzerland
 EAC,Executive Air Charter,EXECAIR,United States
 EAD,Escola De Aviacao Aerocondor,AERO-ESCOLA,Portugal
@@ -1340,12 +1620,17 @@ EAK,Euro-Asia Air,EAKAZ,Kazakhstan
 EAL,Eastern Air Lines,EASTERN,United States
 EAM,Embassy Airlines,EMBASSY AIR,Nigeria
 EAN,Skypower Express Airways,NIGERIA EXPRESS,Nigeria
+EAO,Elitavia San Marino SRL,MARINO,SM
 EAP,Aero-Pyrenees,AERO-PYRENEES,France
 EAQ,Eastern Australia Airlines,EASTERN,Australia
 EAR,Transporte Ejecutivo Aéreo,EJECUTIVO-AEREO,Mexico
+EAS,Executive Aerospace,,South Africa
 EAT,Air Transport,TRANS EUROPE,Slovakia
+EAU,Elitavia Ltd,ELITE,Malta
 EAV,Eagle Airlines Luftverkehrsges,MAYFLOWER,Austria
+EAW,Walya Airways,WALYA,ET
 EAX,Eastern Air Executive,EASTEX,United Kingdom
+EAY,Aero Airlines,,Estonia
 EAZ,Eastern Air,EASAIR,Zambia
 EBA,Bond Aviation,BOND AVIATION,Italy
 EBC,Aero Ejecutivo De Baja California,CALIXJET,Mexico
@@ -1373,9 +1658,11 @@ ECU,Ecuavia,ECUAVIA,Ecuador
 ECV,Ecuatoguineana De Aviación (EGA),EQUATOGUINEA,Equatorial Guinea
 ECX,Ecomex Air Cargo,AIR ECOMEX,Angola
 ECY,Euroceltic Airways,ECHELON,United Kingdom
+EDA,Aerolineas Nacionales Del Ecuador,,Ecuador
 EDC,Air Charter Scotland,SALTIRE,United Kingdom
 EDD,Líneas Aéreas Ejectuivas De Durango,LINEAS DURANGO,Mexico
 EDG,Jet Edge International,EDGE,United States
+EDI,Eastern Atlantic Charters,,United States
 EDJ,Edwards Jet Center of Montana,EDWARDS,United States
 EDL,Polizeihubschrauberstaffel Bayern,POLICE EDELWEISS,Germany
 EDO,Elidolomiti,ELIDOLOMITI,Italy
@@ -1386,16 +1673,25 @@ EDY,Apollo Air Service,STOBART,United Kingdom
 EEA,Empresa Ecuatoriana De Aviación,ECUATORIANA,Ecuador
 EEF,Estonian Air Force,ESTONIAN AIR FORCE,Estonia
 EEL,Eagle European,,United Kingdom
+EEM,Ejecutivo Aereo de Mexico S.A. de C.V.,EJEAERMEX,Mexico
 EES,Eagle Express,,Serbia
 EET,Air Este,AESTE,Spain
 EEU,Eurofly Service,EUROFLY,Italy
+EEX,Executive Express Aviation SA de CV,,Mexico
 EEZ,Eurofly,E-FLY,Italy
+EFA,Far Eastern Air Transport,,Taiwan
+EFB,Emerald Jet,EMERALD JETS,Lebanon
 EFC,Air Mana,FLIGHT TAXI,France
 EFD,Eisele Flugdienst,EVER FLIGHT,Germany
+EFF,Westair Aviation,EMERALD,IE
 EFG,Elifriulia,ELIFRIULIA,Italy
 EFS,EFAOS- Agencia De Viagens e Turismo,EFAOS,Angola
 EFT,Embassy Freight Company,EMBASSY FREIGHT,United States
+EFX,Easy Fly Express,EASY EXPRESS,BD
+EFY,EasyFly,,Colombia
+EGC,First Wing Aircraft Charter and Maintenance,EAGLE CREEK,United States
 EGF,American Eagle Airlines,EAGLE FLIGHT,United States
+EGH,BBN-Airways,,United Kingdom
 EGJ,Eagle Jet Charter,EAGLE JET,United States
 EGL,Capital Trading Aviation,PRESTIGE,United Kingdom
 EGN,Eagle Aviation France,FRENCH EAGLE,France
@@ -1408,6 +1704,8 @@ EGX,Eagle Air Company,THAI EAGLE,Thailand
 EGY,Egyptian Air Force,,Egypt
 EHA,East Hampton Aire,AIRE HAMPTON,United States
 EHD,E H Darby Aviation,PLATINUM AIR,United States
+EHM,Euro Harmony,,Portugal
+EHN,East Horizon,,Afghanistan
 EHR,Valfell-Verkflug,ROTOR,Iceland
 EIA,Evergreen International Airlines,EVERGREEN,United States
 EIC,Express International Cargo,EXCARGO,São Tomé and Príncipe
@@ -1419,6 +1717,7 @@ EIX,Ei Air Exports,AIR EXPORTS,Ireland
 EJA,NetJets,EXECJET,United States
 EJC,Grupo De Aviación Ejecutiva,GRUPOEJECUTIVA,Mexico
 EJD,Elite Jets,ELITE DUBAI,United Arab Emirates
+EJE,Hebei Tonghe General Aviation,VOODOO,China
 EJM,Executive Jet Management,JET SPEED,United States
 EJO,Execujet Middle East,MIDJET,United Arab Emirates
 EJP,Aeroservicios Ejecutivos Corporativos,EJECCORPORATIVOS,Mexico
@@ -1429,12 +1728,16 @@ EJV,Compania Ejecutiva,EJECUTIVA,Mexico
 EJX,Egyptian Aviation,,Egypt
 EKA,Equaflight Service,EQUAFLIGHT,Republic of the Congo
 EKC,East Kansas City Aviation,BLUE GOOSE,United States
+EKJ,Equajet,EQUAJET,Republic of the Congo
+EKY,EasySky,,Honduras
 ELA,Eastland Air,,Australia
 ELB,Ellinair,ELLINAIR HELLAS,Greece
+ELC,Small Planet Airlines,,Lithuania
 ELE,Euroairlines,EUROLINE,United Kingdom
 ELG,Elangeni,,Austria
 ELH,Elilario Italia,LARIO,Italy
 ELJ,Delta Private Jets,ELITE JET,United States
+ELK,ELK Airways,,Estonia
 ELL,Estonian Air,ESTONIAN,Estonia
 ELM,Crelam,CRELAM,Mexico
 ELN,Eleron Aviation Company,ELERON,Ukraine
@@ -1453,6 +1756,7 @@ EMD,Eaglemed (Ballard Aviation),EAGLEMED,United States
 EME,Eastern Metro Express,EMAIR,United States
 EMI,Premium Air Shuttle,BLUE SHUTTLE,Nigeria
 EMJ,Yellow Air Taxi/Friendship Airways,,United States
+EMM,Emperor Aviation,RULER,Malta
 EMN,Examiner Training Agency,AGENCY,United Kingdom
 EMP,Empire Air Service,EMPIRE,United States
 EMR,Zenmour Airlines,ZENMOUR,Mauritania
@@ -1464,7 +1768,9 @@ ENA,Dirección General de Aviación Civil y Telecomunicasciones,ENA,Spain
 ENC,Endecots,ENDECOTS,Ecuador
 END,Arrendadora y Transportadora Aérea,ARRENDADORA,Mexico
 ENI,Enimex,ENIMEX,Estonia
+ENJ,Enerjet,,Canada
 ENK,Executive Airlink,SUNBIRD,United States
+ENL,Servicios Optimos de Aeroenlace,OPTIMOS,Mexico
 ENR,Scenic Air,,Namibia
 ENS,Entergy Services,ENTERGY SHUTTLE,United States
 ENT,Enter Air,ENTER,Poland
@@ -1475,40 +1781,54 @@ ENZ,Jota Aviation,,United Kingdom
 EOA,Elilombarda,LOMBARDA,Italy
 EOL,Airailes,EOLE,France
 EOM,Aero Ermes,AERO ERMES,Mexico
+EOS,Eliossola,,Italy
+EPA,Shenzhen Donghai Airlines,,China
 EPB,Eastern Pacific Aviation,EAST PAC,Canada
 EPC,Espace Aviation Services,ESPACE,Democratic Republic of the Congo
 EPE,Aero Empresarial,AEROEMPRESARIAL,Mexico
+EPJ,Taespejo,ESPEJO,Spain
 EPL,Aero Transportes Empresariales,EMPRESARIALES,Mexico
 EPR,Express Airways,EMPEROR,Slovenia
+EPS,Epps Air Service,,United States
 EPU,Aero Elite Acapulco,ELITACAPULCO,Mexico
 EQC,Ecuatorial Cargo,ECUA-CARGO,Equatorial Guinea
+EQL,Air São Tomé and Príncipe,EQUATORIAL,São Tomé and Príncipe
 EQT,Equatorial Airlines,,Equatorial Guinea
 EQZ,Equatair Air Services (Zambia),ZAMBIA CARGO,Zambia
+ERA,Aerotaxis Tucan SA de CV,ROCAN,Mexico
 ERC,Esso Resources Canada,ESSO,Canada
 ERE,Erie Airways,AIR ERIE,United States
 ERF,Erfoto,ERFOTO,Portugal
+ERG,Avianergo,,Russia
 ERH,Era Helicopters,ERAH,United States
 ERI,Aero Servicios Regiomontanos,ASERGIO,Mexico
 ERJ,Eurojet Italia,JET ITALIA,Italy
 ERK,Aerosec,AEROSEC,Chile
 ERM,Aeromaan,EOMAAN,Mexico
 ERO,Aeroecom,AEROECOM,Venezuela
+ERR,Era Alaska,,United States
 ERT,Eritrean Airlines,ERITREAN,Eritrea
 ERV,Yerevan-Avia,YEREVAN-AVIA,Armenia
 ERX,Earth Airlines Services,EARTH AIR,Nigeria
+ERY,Sky Quest LLC,ERIE SHORE,United States
+ES2,Usa Sky Cargo,,United States
 ESB,Aereosaba,AEREOSABA,Mexico
 ESC,El Sol De América,SOLAMERICA,Venezuela
+ESD,PT. Eastindo Services,EASTINDO,Indonesia
 ESE,Ensenada Vuelos Especiales,ENSENADA ESPECIAL,Mexico
 ESF,Estafeta Carga Aérea,,Mexico
 ESI,ESI Eliservizi Italiani,ELISERVIZI,Italy
 ESJ,Eastern SkyJets,EASTERN SKYJETS,United Arab Emirates
+ESK,SkyEurope,,Slovakia
 ESL,Russian Sky Airlines,RADUGA,Russia
+ESM,Executive Aircraft Services,EXEC AIRCRAFT,Lebanon
 ESN,Euro Sun,EURO SUN,Turkey
 ESO,Avitat,,United Kingdom
 ESR,Eastar Jet,EASTAR,South Korea
 ESS,Eos Airlines,NEW DAWN,United States
 EST,Carga Express Internacional,CARGAINTER,Mexico
 ESU,Aerolíneas Ejecutivas Del Sureste,ALESUR,Mexico
+ESW,Silk Way Business Aviation,W-BUSINESS,Azerbaijan
 ESX,Euroskylink,CATFISH,United Kingdom
 ESZ,Aeronáutica La Esperanza,ESPERANZA,Mexico
 ETA,Estrellas Del Aire,ESTRELLAS,Mexico
@@ -1521,17 +1841,24 @@ ETL,Patterson Aviation Company,ENTEL,United States
 ETM,Etram Air Wing,ETRAM,Angola
 ETN,Chim-Nir Aviation,CHIMNIR,Israel
 ETP,Empire Test Pilots' School,TESTER,United Kingdom
+ETR,Aerolineas Estelar,ESTEL,Venezuela
 ETS,Flygtransporter I Nykoping,EXTRANS,Sweden
 ETV,European Executive,EURO EXEC,United Kingdom
+EU9,Europe Jet,,France
 EUC,Eurocontrol,,Belgium
+EUD,Air Italy Egypt,,Egypt
 EUG,Euroguineana de Aviación,EUROGUINEA,Equatorial Guinea
+EUJ,EUjet,,Ireland
+EUK,Aer Lingus U.K.,GREEN FLIGHT,United Kingdom
 EUL,Euro Link,,Germany
 EUP,Pan Europeenne Air Service,SAVOY,France
 EUT,European 2000 Airlines,FIESTA,Malta
 EUU,Euroamerican Air,EUROAMERICAN,Uruguay
+EUV,EuropeSky,,Germany
 EUW,EFS European Flight Service,EUROWEST,Sweden
 EUY,EU Airways,EUROAIRWAYS,Ireland
 EVA,EVA Air,EVA,Taiwan
+EVC,Comfort Express Virtual Charters Albany,,United States
 EVE,Air Evex,SUNBEAM,Germany
 EVK,Everett Aviation,EVERETT,Kenya
 EVL,Evolem Aviation,EVOLEM,France
@@ -1539,14 +1866,19 @@ EVM,Natural Environment Research Council,SCIENCE,United Kingdom
 EVN,Euraviation,EURAVIATION,Italy
 EVR,Aeronautical Academy of Europe,DIANA,Portugal
 EVT,Everett Limited,,Tanzania
+EVX,ATR,GREEN SPIRIT,France
+EVY,Royal Australian Air Force,,Australia
+EWA,East-West Airlines,,Australia
 EWE,Eurowings Europe,,Austria
 EWG,Eurowings,EUROWINGS,Germany
 EWR,Ewa Air,MAYOTTE AIR,France
 EWS,Enterprise World Airways,WORLD ENTERPRISE,Democratic Republic of the Congo
 EWW,Emery Worldwide Airlines,EMERY,United States
+EWZ,East Wing,E-WING,Kazakhstan
 EXA,Execair Aviation,CANADIAN EXECAIRE,Canada
 EXB,Brazilian Army Aviation,BRAZILIAN ARMY,Brazil
 EXC,European Executive Express,ECHO EXPRESS,Sweden
+EXD,ExecuJet Africa,PLATINUM EXEC,South Africa
 EXE,Executive Flight,EXEC,United States
 EXF,Eximflight,EXIMFLIGHT,Mexico
 EXG,Air Exchange,EXCHANGE,United States
@@ -1567,6 +1899,7 @@ EXX,International Air Corporation,EXPRESS INTERNATIONAL,United States
 EXY,South African Express,EXPRESSWAYS,South Africa
 EXZ,East African Safari Air Express,TWIGA,Kenya
 EYE,F.S. Air Service,SOCKEYE,United States
+EZA,Eznis Airways,,Mongolia
 EZB,Flugschule Eichenberger,EICHENBURGER,Switzerland
 EZD,Philippines AirAsia,REDHOT,Philippines
 EZE,Eastern Airways,EASTFLIGHT,United Kingdom
@@ -1574,6 +1907,7 @@ EZJ,Ezjet GT,GUYANA JET,Guyana
 EZS,easyJet Switzerland,TOPSWISS,Switzerland
 EZX,Eagle Express Air Charter,EAGLEXPRESS,Malaysia
 EZY,easyJet UK,EASY,United Kingdom
+EZZ,ETF Airways,ENTERPRIZE,Croatia
 FAB,First Air,FIRST AIR,Canada
 FAC,Atlantic Helicopters,FAROECOPTER,Denmark
 FAD,Rog-Air,AIR FRONTIER,Canada
@@ -1581,6 +1915,7 @@ FAE,Freshaer,WILDGOOSE,United Kingdom
 FAF,Force Aerienne Francaise,FRENCH AIR FORCE,France
 FAG,Argentine Air Force,FUAER,Argentina
 FAH,Farnair Hungary,BLUE STRIP,Hungary
+FAJ,Air Fiji,,Fiji
 FAK,Financial Airxpress,FACTS,United States
 FAL,Friendship Air Alaska,FRIENDSHIP,United States
 FAM,Fumigación Aérea Andaluza,FAASA,Spain
@@ -1599,7 +1934,11 @@ FAY,Fayban Air Services,FAYBAN AIR,Nigeria
 FAZ,Flint Aviation Services,FLINT AIR,United States
 FBA,Fab Air,FAB AIR,Kyrgyzstan
 FBF,Fine Airlines,FINE AIR,United States
+FBL,Fly Brasil,,Brazil
 FBO,TAG Farnborough Airport,,United Kingdom
+FBR,Baden Aircraft Operations,,Germany
+FBS,FlyBosnia,BOSNIA AIR,SA
+FBU,French Bee,FRENCH BEE,France
 FBW,Aviation Data Systems,,United States
 FBZ,Flybondi,BONDI,Argentina
 FCA,First Choice Airways,JETSET,United Kingdom
@@ -1610,6 +1949,7 @@ FCI,Air Carriers,FAST CHECK,United States
 FCJ,AirSprint US,FRACJET,United States
 FCK,FCS Flight Calibration Services,NAV CHECKER,Germany
 FCL,Florida Coastal Airlines,FLORIDA COASTAL,United States
+FCM,Flybe Finland Oy,,Finland
 FCN,Falcon Air,FALCON,Sweden
 FCO,Aerofrisco,AEROFRISCO,Mexico
 FCP,Nelson Aviation College Ltd,FLIGHTCORP,New Zealand
@@ -1619,8 +1959,9 @@ FCT,Fly CI Limited,DEALER,United Kingdom
 FCU,Alfa 4,,Mexico
 FCV,Flight Centre Victoria,NAVAIR,Canada
 FDA,African Airlines,AIR SANKORE,Mali
-FDB,Flydubai,SKYDUBAI,UAE
+FDB,Flydubai,SKYDUBAI,United Arab Emirates
 FDC,Garden City Helicopters,,New Zealand
+FDD,Feeder Airlines,,Sudan
 FDF,IVV Femida,,Russia
 FDL,Farmingdale State University,FARMINGDALE STATE,United States
 FDN,Dolphin Air,FLYING DOLPHIN,United Arab Emirates
@@ -1628,6 +1969,7 @@ FDO,France Douanes,FRENCH CUSTOM,France
 FDP,Flight Dispatch Services,,Poland
 FDR,Federal Air,FEDAIR,South Africa
 FDS,African Medical and Research Foundation,FLYDOC,Kenya
+FDT,Freedom Airline Express,FREEDOM EAGLE,Kenya
 FDX,FedEx Express,FEDEX,United States
 FDY,Sun Air International,FRIENDLY,United States
 FEA,Far Eastern Air Transport,Far Eastern,Taiwan
@@ -1657,19 +1999,27 @@ FFR,Fischer Air,FISCHER,Czech Republic
 FFS,Florida Department of Agriculture,FORESTRY,United States
 FFT,Frontier Airlines,FRONTIER FLIGHT,United States
 FFU,GEC Marconi Avionics,FERRANTI,United Kingdom
+FFV,Fly540,,Kenya
 FFY,Fun Flying Thai Air Service,FUN FLYING,Thailand
 FGA,Georgian Aviation Federation,GEORGIA FED,Georgia
 FGC,Departament d'Agricultura de la Generalitat de Catalunya,FORESTALS,Spain
+FGD,Conair Aviation,FIREGUARD,Canada
 FGE,Fly Georgia,GEORGIA WING,Georgia
+FGL,Futura Gael,,Ireland
 FGN,National Gendarmerie,FRANCE GENDARME,France
 FGP,Flying-Research Aerogeophysical Center,FLYING CENTER,Russia
+FGR,Trans-Pacific Jets,FRIGATE,United States
 FGS,Elitellina,ELITELLINA,Italy
 FGT,Aero Freight,FREIAERO,Mexico
+FGW,Fly Gangwon,GANGWON,South Korea
 FGY,Froggy Corporate Aviation,,Australia
 FHE,Hello,FLYHELLO,Switzerland
+FHI,FlyHigh Airlines Ireland (FH),,Ireland
 FHL,Fast Helicopters,FINDON,United Kingdom
+FHM,Freebird Airlines Europe,EUROBIRD,Malta
 FHS,Forth and Clyde Helicopter Services,HELISCOT,United Kingdom
 FHY,Freebird Airlines,FREEBIRD AIR,Turkey
+FI5,Fly One,,Moldova
 FIA,Fly One,Fly One,Moldova
 FIC,Aerosafin,AEROSAFIN,Mexico
 FIF,Air Finland,AIR FINLAND,Finland
@@ -1680,15 +2030,21 @@ FIN,Finnair,FINNAIR,Finland
 FIR,First Line Air,FIRSTLINE AIR,Sierra Leone
 FIV,CitationAir,FIVE STAR,United States
 FIX,Airfix Aviation,AIRFIX,Finland
+FJA,Fiji Link,LINK FIJI,FJ
 FJC,Falcon Jet Centre,FALCONJET,United Kingdom
 FJE,Silverjet,ENVOY,United Kingdom
 FJI,Fiji Airways,PACIFIC,Fiji
+FJK,Fly Jet Kz,,Kazakhstan
 FJM,Fly Jamaica Airways,GREENHEART,Jamaica
+FJO,Flexjet Operations Malta Limited,FLEX MALTA,Malta
+FJR,Fly Jordan,SOLITAIRE AIR,Jordan
 FJS,Florida Jet Service,FLORIDAJET,United States
+FKA,Flying kangaroo Airline,,Australia
 FKI,FLM Aviation Mohrdieck,KIEL AIR,Germany
 FKL,Kelner Airways,KELNER,Canada
 FKS,Focus Air,FOCUS,United States
 FLA,Air Florida,PALM,United States
+FLB,German Air Force - FLB,,Germany
 FLC,FINFO Flight Inspection Aircraft,FLIGHT CHECK,United States
 FLD,Air Falcon,,Pakistan
 FLE,Flair Airlines,FLAIR,Canada
@@ -1696,24 +2052,30 @@ FLF,Friendship Airlines,FRIEND AIR,Uganda
 FLG,Pinnacle Airlines,FLAGSHIP,United States
 FLH,Sky Bus,MILE HIGH,United States
 FLI,Atlantic Airways,FAROELINE,Faroe Islands
+FLJ,Sirio UK,FLAIRJET,GB
 FLK,Flylink Express,FLYLINK,Spain
 FLL,Federal Airlines,FEDERAL AIRLINES,Sweden
 FLM,Fly Air,FLY WORLD,Turkey
 FLN,Flamingo Air-Line,ILIAS,Kazakhstan
 FLO,Flycom,FLYCOM,Slovenia
+FLP,Aeroclub Flaps,,Spain
 FLR,Fleetair,FLEETAIR,South Africa
+FLS,Fairlines,,Netherlands
+FLT,Flightline,,United Kingdom
 FLU,Flugschule Basel,YELLOW FLYER,Switzerland
 FLW,FLowair Aviation,QUICKFLOW,France
-FLX,Flight Express, Inc.,FLIGHT EXPRESS,United States
+FLX,Flight Express Inc.,FLIGHT EXPRESS,United States
 FLY,Fly Me Sweden,FLYBIRD,Sweden
 FLZ,Aero Leasing,AIR FLORIDA,United States
 FMC,Claessens International Limited,CLAESSENS,United Kingdom
+FMF,Egyptian Aviation Academy,EGYPT ACADEMY,Egypt
 FMG,FMG Verkehrsfliegerschule Flughafen Paderborn-Lippstadt,HUSKY,Germany
 FMI,FMI Air,FIRST MYANMAR,Myanmar
 FMR,Flamingo Air,FLAMINGO AIR,United States
 FMS,Hadison Aviation,HADI,United States
 FMT,Air Fret De Mauritanie,,Mauritania
 FMY,Aviation Legere De L'Armee De Terre,FRENCH ARMY,France
+FN1,Finlandian,,Finland
 FNA,Norlandair,NORLAND,Iceland
 FNC,Finalair Congo,FINALAIR CONGO,Republic of the Congo
 FNF,Finnish Air Force,FINNFORCE,Finland
@@ -1728,31 +2090,39 @@ FNX,Aero Fenix,AERO FENIX,France
 FNY,France Marine Nationale,FRENCH NAVY,France
 FOB,Ford Motor Company,FORDAIR,United Kingdom
 FOC,Office Federal De'Aviation Civile,FOCA,Switzerland
+FOF,Fred. Olsen,,Norway
 FOI,Flight Ops International,,United States
 FOM,Freedom Air,FREE AIR,New Zealand
 FOP,Fokker,,Netherlands
 FOR,Formula One Management,FORMULA,United Kingdom
 FOS,Bel Limited,,Russia
+FOX,Flyr AS,GREENSTAR,Norway
 FPA,Flygprestanda,,Sweden
 FPG,TAG Aviation,TAG AVIATION,Switzerland
 FPO,Europe Airpost,FRENCH POST,France
 FPR,Peruvian Air Force,,Peru
 FPS,Flightpass Limited,FLIGHTPASS,United Kingdom
+FPT,FlyPortugal,,Portugal
 FPY,African Company Airlines,AFRICOMPANY,Democratic Republic of the Congo
 FQA,Quikjet Cargo Airlines,QUIK LIFT,India
+FQR,CheapFlyingInternational,,France
 FRA,FR Aviation,RUSHTON,United Kingdom
 FRB,Fly Rak,RAKWAY,United Arab Emirates
 FRC,Icare Franche Compte,FRANCHE COMPTE,France
+FRD,Ford Motor Company,,United States
 FRE,FlyPelican,PELICAN,Australia
 FRF,Fleet Air International,FAIRFLEET,Hungary
 FRG,Freight Runners Express,FREIGHT RUNNERS,United States
+FRH,ACE Belgium Freighters,ACE FREIGHT,Belgium
 FRJ,Afrijet Airlines,AFRIJET,Nigeria
 FRK,Afrika Aviation Handlers,AFRIFAST,Kenya
 FRL,Freedom Airlines,FREEDOM AIR,United States
 FRM,Federal Armored Service,FEDARM,United States
+FRN,Farnair Netherlands,,Netherlands
 FRQ,Afrique Chart'air,CHARTER AFRIQUE,Cameroon
 FRR,Fresh Air,FRESH AIR,Nigeria
 FRT,Aerofreight Airlines,,Russia
+FRV,Royal Moroccan Air Force,,Morocco
 FRW,Farwest Airlines,FARWEST,United States
 FRX,Fort Aero,FORT AERO,Estonia
 FSA,Foster Aviation,FOSTER-AIR,United States
@@ -1760,7 +2130,9 @@ FSB,FSB Flugservice & Development,SEABIRD,Germany
 FSC,Four Star Aviation / Four Star Cargo,FOUR STAR,United States
 FSD,EFS-Flugservice,FLUGSERVICE,Germany
 FSE,Alpine Flightservice,,Switzerland
+FSF,Fly7 Finland,ROCKY,Finland
 FSH,Flash Airlines,FLASH,Egypt
+FSK,Africa Charter Airlines,AFRICAN SKY,South Africa
 FSL,Flight Safety Limited,FLIGHTSAFETY,United Kingdom
 FSR,Flightstar Corporation,FLIGHTSTAR,United States
 FST,Aeros Limited,FAST TRACK,United Kingdom
@@ -1770,27 +2142,36 @@ FSX,Flagship Express Services,FLAG,United States
 FSY,Algonquin Airlink,FROSTY,Canada
 FTA,Frontier Flying Service,FRONTIER-AIR,United States
 FTC,Air Affaires Tchad,AFFAIRES TCHAD,Chad
+FTD,AB Jets,FORTITUDE,United States
 FTE,Fotografia F3,FOTOGRAFIA,Spain
 FTH,Mountain Aviation,FOOTHILL,United States
+FTI,FTI Fluggesellschaft,,Germany
 FTL,Flightline,FLIGHT-AVIA,Spain
 FTM,Flyteam Aviation,FLYTEAM,United Kingdom
+FTN,Victory Air,FRONTRUNNER,United States
 FTP,Keystone Aerial Surveys,FOOTPRINT,United States
 FTR,Finist'air,FINISTAIR,France
 FTS,First Sabre,FIRST SABRE,Mexico
 FTY,ABC Bedarfsflug,FLY TYROL,Austria
 FTZ,Fastjet,GREY BIRD,Tanzania
+FUA,Futura International Airways,,Spain
 FUF,Servicios Aereos Fun Fly,SERVIFUN,Mexico
 FUJ,Fujairah Aviation Centre,FUJAIRAH,United Arab Emirates
 FUM,Fuxion Line Mexico,FUNLINE,Mexico
 FUN,Funtshi Aviation Service,FUNTSHI,Democratic Republic of the Congo
 FUT,Aereo Futuro,AEREO FUTURO,Mexico
 FVA,Cardinal/Air Virginia,AIR VIRGINIA,United States
+FVG,VG Airlines (IV),,Belgium
 FVK,FlyViking,BALDER,Norway
+FVM,Flugfelag Vestmannaeyja,,Iceland
 FVS,Falcon Aviation Services,FALCON AVIATION,United Arab Emirates
+FWA,Interstate Airline,,Netherlands
+FWC,Freeway Air,,Netherlands
 FWD,Fair Wind Air Charter,FAIR WIND,United Arab Emirates
 FWI,Air Caraïbes,FRENCH WEST,France
 FWK,Flightworks,,United States
 FWL,Florida West International Airways,FLO WEST,United States
+FWR,Flightware,FLIGHTAWARE,United States
 FWQ,Flight West Airlines,UNITY,Australia
 FWY,Fairways Corporation,FAIRWAYS,United States
 FWZ,Flugwerkzeuge Aviation Software,,Austria
@@ -1801,13 +2182,21 @@ FXI,Air Iceland,FAXI,Iceland
 FXL,Fly Excellent,FLY EXCELLENT,Sweden
 FXR,Foxair,WILDFOX,Italy
 FXT,Flexflight,,Denmark
+FXW,AAG - Associated Aircraft Group,FLEXWING,United States
+FXX,Felix Airways,,Yemen
+FXY,Flexair,,Netherlands
 FYA,Servicios Aéreos Integrales / Flyant,FLYANT,Spain
+FYD,Flying Devil SA,,CH
 FYE,Easy Link Aviation Services,FLYME,Nigeria
 FYG,Flying Service,FLYING GROUP,Belgium
 FYH,Flyhy Cargo Airlines,FLY HIGH,Thailand
+FYJ,FLYJET,,Poland
 FYL,Flying Group,FLYING GROUP,Belgium
 FYN,Comfort Air,FLYNN,Germany
 FYS,American Flyers,AMERICAN FLYERS,United States
+FZA,Fuzhou Airlines,,China
+FZW,Fly Africa Zimbabwe,,Zimbabwe
+GA0,Global Airlines,,Argentina
 GAA,Business Express,BIZEX,United States
 GAB,Gendall Air,GENDALL,Canada
 GAC,GlobeAir,DREAM TEAM,Austria
@@ -1831,11 +2220,13 @@ GAT,Gulf Air Inc,GULF TRANS,United States
 GAU,Aerogaucho,AEROGAUCHO,Uruguay
 GAV,Granada Aviación,GRANAVI,Spain
 GAX,Full Express,GRAND AIRE,United States
+GBA,Gulf Air Bahrain,,Bahrain
 GBB,Global Aviation Operations,GLOBE,South Africa
 GBC,Guangxi Beibu Gulf Airlines,SPRAY,China
 GBE,Gabon Express,GABEX,Gabon
 GBH,Global Avia Handling,,Russia
 GBJ,Aero Business Charter,GLOBAL JET,Germany
+GBK,Gabon Airlines,,Gabon
 GBL,GB Airways,GEEBEE AIRWAYS,United Kingdom
 GBN,Atlantic Airlines,ATLANTIC GABON,Gabon
 GBO,Ogooue Air Cargo,,Gabon
@@ -1843,19 +2234,24 @@ GBR,Rader Aviation,GREENBRIER AIR,United States
 GBS,Global Air Services Nigeria,GLOBAL SERVE,Nigeria
 GBT,A-Jet Aviation Aircraft Management,GLOBETROTTER,Austria
 GBX,GB Airlink,ISLAND TIGER,United States
+GCA,Grand Cru Airlines,,Lithuania
 GCB,Lignes Nationales Aeriennes - Linacongo,LINACONGO,Republic of the Congo
 GCC,GECAS,GECAS,Ireland
 GCF,Aeronor,AEROCARTO,Spain
 GCH,Gama Aviation Switzerland,GAMA SWISS,Switzerland
+GCK,Aerogem Cargo,,Ghana
+GCL,CargoLogic Germany,SAXONIAN,Germany
 GCM,Comair Flight Services,GLOBECOM,South Africa
 GCN,Gulf Central Airlines,GULF CENTRAL,United States
 GCO,Gemini Air Cargo,GEMINI,United States
 GCR,Tianjin Airlines,BO HAI,China
 GCS,GCS Air Service,GALION,United States
+GCT,Gulf Coast Aviation Inc,GULF COAST,United States
 GCW,Global Air Crew,GLOBALCREW,Denmark
 GCY,CHC Global Operations International,HELIBIRD,United Kingdom
 GDA,GoldAir,AIR PARTNER,United Kingdom
 GDB,Gendarmerie Belge,BELGIAN GENERMERIE,Belgium
+GDC,Grand China Air,,China
 GDD,Golden Airlines,GOLDEN AIRLINES,United States
 GDE,Servicios Aéreos Gadel,GADEL,Mexico
 GDF,DF Aviation,,Ukraine
@@ -1864,26 +2260,34 @@ GDH,Guneydogu Havacilik Isletmesi,RISING SUN,Turkey
 GDK,Goldeck-Flug,GOLDECK FLUG,Austria
 GDN,Gerry's Dnata,,Pakistan
 GDQ,Lincoln Air National Guard,,United States
+GDR,Gadair European Airlines,,Spain
+GDS,Steelman Aviation Inc,GOLDSTRIKE,United States
 GEA,Guinea Ecuatorial Airlines,GEASA,Equatorial Guinea
 GEC,Lufthansa Cargo,LUFTHANSA CARGO,Germany
 GED,Europe Air Lines,LANGUEDOC,France
 GEE,Geesair,GEESAIR,Canada
+GEG,Georgian Airlines,,Georgia
 GEL,GeoSky,SKY GEORGIA,Georgia
 GEN,GENSA,GENSA-BRASIL,Brazil
 GER,German Airways,,Germany
 GES,Gestair,GESTAIR,Spain
 GET,Get High,AIR FLOW,Portugal
+GEX,Aero Expedition,AERO GEORGIA,GE
+GF5,Global Freightways,,United States
 GFA,Gulf Air,GULF AIR,Bahrain
 GFC,Gail Force Express,GAIL FORCE,United States
 GFD,Gesellschaft Fur Flugzieldarstellung,KITE,Germany
+GFE,Archer Daniels Midland Co,,United States
 GFF,Griffin Aviation,GRIFFIN AIR,Cyprus
 GFG,Georgian National Airlines,NATIONAL,Georgia
 GFI,Caribbean Star Airlines,CARIB STAR,Antigua and Barbuda
+GFM,Grafair,PARROT,Sweden
 GFN,The 955 Preservation Group,GRIFFON,United Kingdom
 GFO,Aerovías del Golfo,AEROVIAS GOLFO,Mexico
 GFS,Gulfstream Airlines,GULFSTAR,United States
 GFT,Gulfstream International Airlines,GULF FLIGHT,United States
 GFW,GFW Aviation,,Australia
+GFY,Greenfly,,Spain
 GGA,First Flying Squadron,JAWJA,United States
 GGC,Cargo 360,LONG-HAUL,United States
 GGE,Gobierno De Guinea Ecuatorial,,Equatorial Guinea
@@ -1894,6 +2298,7 @@ GGS,GATSA,GATSA,Mexico
 GGT,Trans Island Airways,THUNDERBALL,Bahamas
 GGV,Houston Jet Services,GREGG AIR,Austria
 GGZ,Global Georgian Airways,GLOBAL GEORGIAN,Georgia
+GHA,Ghana Airways,,Ghana
 GHB,Ghana International Airlines,GHANA AIRLINES,Ghana
 GHI,GH Stansted Limited,,United Kingdom
 GHL,Aviance,HANDLING,United Kingdom
@@ -1907,20 +2312,27 @@ GHY,German Sky Airlines,GERMAN SKY,Germany
 GIA,Garuda Indonesia,INDONESIA,Indonesia
 GIB,GR-Avia,GRAVIA,Guinea
 GIC,Compagnie de Bauxites de Guinee,CEBEGE,Guinea
+GIE,Elysian Airlines,,Cameroon
+GIF,Guinee Airlines,,Guinea
 GIG,Gacela Air Cargo,GACELA AIR,Mexico
 GIH,Union des Transports Africains de Guinee,TRANSPORT AFRICAIN,Guinea
 GIJ,Guinea Airways,GUINEA AIRWAYS,Guinea
 GIK,Seba Airlines,SEBA,Guinea
 GIL,African International Transport,AFRICAN TRANSPORT,Guinea
+GIO,GIO Business Aviation d.o.o.,GIO-AVIA,SI
 GIP,Air Guinee Express,FUTURE EXPRESS,Guinea
 GIQ,Guinee Paramount Airlines,GUIPAR,Guinea
 GIY,Probiz Guinee,PROBIZ,Guinea
 GIZ,Africa Airlines,AFRILENS,Guinea
 GJA,Globe Jet,,Lebanon
 GJB,Trans-Air-Link,SKY TRUCK,United States
+GJE,Global Air Charters Inc,GLOBAL JETS,United States
+GJI,Gainjet Ireland Limited,GAINSTAR,IE
+GJM,Airhub Airlines,AIRHUB,Malta
 GJS,GoJet Airlines,LINDBERGH,United States
 GJT,Gestión Aérea Ejecutiva,BANJET,Spain
 GKA,US Army Parachute Team,GOLDEN KNIGHTS,United States
+GKY,Gama Aviation,GAMA CAYMAN,Cayman Islands
 GLA,Great Lakes Airlines,LAKES AIR,United States
 GLB,Global Airways (GLB),GLO-AIR,United States
 GLC,Global Aircargo,,Bahrain
@@ -1948,6 +2360,7 @@ GMI,Germania,GERMANIA,Germany
 GMJ,Gamisa Aviación,GAMISA,Spain
 GML,G & L Aviation,GEEANDEL,South Africa
 GMM,Aerotaxis Guamuchil,AEROGUAMUCHIL,Mexico
+GMN,Garmin,GARMIN,United States
 GMQ,Germania Express,CORGI,Germany
 GMR,Golden Myanmar Airlines,GOLDEN MYANMAR,Myanmar
 GMS,Aeroservicios Gama,SERVICIOS GAMA,Mexico
@@ -1958,6 +2371,7 @@ GND,Grand Airways,GRAND VEGAS,United States
 GNF,Gandalf Airlines,Gandalf,Italy
 GNJ,Gain Jet Aviation,HERCULES JET,Greece
 GNL,135 Airways,GENERAL,United States
+GNN,Georgian International Airlines,,Georgia
 GNR,Gambia International Airlines,GAMBIA INTERNATIONAL,Gambia
 GNS,Eastern Executive Air Charter,GENESIS,United Kingdom
 GNT,Amber Air,GINTA,Lithuania
@@ -1966,6 +2380,8 @@ GNY,German Navy,GERMAN NAVY,Germany
 GNZ,General Aviation,GONZO,Poland
 GOA,Alberta Government,ALBERTA,Canada
 GOB,Dash Aviation,PILGRIM,United Kingdom
+GOD,GoDutch,,Netherlands
+GOE,Go Fly (United Kingdom),,United Kingdom
 GOF,Gof-Air,GOF-AIR,Mexico
 GOI,Gofir,SWISS HAWK,Switzerland
 GOJ,EuroJet Aviation,GOJET,United Kingdom
@@ -1980,15 +2396,19 @@ GPA,Golden Pacific Airlines,GOLDEN PAC,United States
 GPC,Gulf Pearl Air Lines,AIR GULFPEARL,Libya
 GPD,Tradewind Aviation,GOODSPEED,United States
 GPE,GP Express Airlines,REGIONAL EXPRESS,United States
+GPL,DLR,GERMAN POLAR,Germany
 GPM,Grup Air-Med,GRUPOMED,Spain
 GPR,GPM Aeroservicio,GPM AEROSERVICIO,Mexico
 GPX,GP Aviation,,Bulgaria
 GRA,Guardian Air Asset Management,FLEX,South Africa
+GRB,Phoenix Air Group,GREY BIRD,United States
 GRD,National Grid plc,GRID,United Kingdom
 GRE,Air Scotland,GREECE AIRWAYS,Greece
 GRG,Air Georgia,AIR GEORGIA,Georgia
 GRI,Air Cargo Center,,São Tomé and Príncipe
 GRL,Air Greenland,GREENLAND,Denmark
+GRN,Rio Grande Air,,United States
+GRO,Allegro,,Mexico
 GRP,Great Plains Airlines,GREAT PLAINS,United States
 GRR,Agroar - Trabalhos Aéreos,AGROAR,Portugal
 GRS,Golden Rule Airlines,GOLDEN RULE,Kyrgyzstan
@@ -1998,26 +2418,33 @@ GRX,Aircompany Grodno,GRODNO,Belarus
 GRY,New York State Police,GRAY RIDER,United States
 GRZ,Government of Zambia Communications Flight,COM FLIGHT,Zambia
 GSA,Garden State Airlines,GARDEN STATE,United States
+GSH,Gama Aviation FZE,GAMAMENA,AE
 GSJ,Grossmann Jet Service,GROSSJET,Czech Republic
 GSK,Global Sky Aircharter,GLOBAL SKY,United States
 GSL,Geographic Air Surveys,SURVEY-CANADA,Canada
+GSM,Flyglobespan,,United Kingdom
 GSP,Airlift Alaska,GREEN SPEED,United States
 GSS,Global Supply Systems,JET LIFT,United Kingdom
 GSV,Agrocentr-Avia,AGRAV,Kazakhstan
 GSW,Sky Wings Airlines,,Greece
 GSY,Guard Systems,GUARD AIR,Norway
+GTA,City Airways,,Thailand
 GTC,Altin Havayolu Tasimaciligi Turizm Ve Ticaret,GOLDEN WINGS,Turkey
 GTH,General Aviation Flying Services,GOTHAM,United States
 GTI,Atlas Air,GIANT,United States
 GTP,Aerotaxi Grupo Tampico,GRUPOTAMPICO,Mexico
 GTR,Gestar,STAR GESTAR,Chile
+GTS,Groupe Transair,TRANSGROUP,SN
 GTV,Empresa de Aviación Aerogaviota,GAVIOTA,Cuba
+GTW,American Air Charter Inc,GATEWAY,United States
 GTX,GTA Air,BIG-DEE,United States
 GTY,National Aviation Company,,Egypt
+GU1,Gulisano airways,,Italy
 GUA,Aerotaxis de Aguascalientes,AGUASCALIENTES,Mexico
 GUE,Aero Servicio Guerrero,AERO GUERRERO,Mexico
 GUF,Gulf African Airlines,GULF AFRICAN,The Gambia
 GUG,Aviateca,AVIATECA,Guatemala
+GUI,Aguilar Connect,,Chile
 GUJ,Gujarat Airways,GUJARATAIR,India
 GUL,Gull Air,GULL-AIR,United States
 GUM,Gum Air,GUM AIR,Suriname
@@ -2028,22 +2455,28 @@ GVG,Flygaktiebolaget Gota Vingar,BLUECRAFT,Sweden
 GVI,Air Victoria Georgia,IRINA,Georgia
 GVN,Gavina,GAVINA,Spain
 GWA,Great Western Air,G-W AIR,United States
+GWC,Gulf Wings FZE,GULF WINGS,AE
 GWI,Germanwings,GERMAN WINGS,Germany
 GWL,Great Wall Airlines,GREAT WALL,China
 GWN,Gwyn Aviation,GWYN,United Kingdom
+GWR,Aura Airlines,LEMON,Spain
 GWS,General Airways,GENAIR,South Africa
 GWY,USA3000 Airlines,GETAWAY,United States
 GXA,Grixona,GRIXONA,Moldova
+GXG,GermanXL,,Germany
 GXL,Star XL German Airlines,STARDUST,Germany
 GXY,Galaxy Airlines,GALAX,Japan
 GYP,Eagle Aviation,GYPSY,United Kingdom
 GZA,Excellent Air,EXCELLENT AIR,Germany
 GZD,Grizodubova Air Company,GRIZODUBOVA AIR,Russia
+GZO,Aeromanagement Group,GEZIRA,United States
 GZP,Gazpromavia,GAZPROMAVIA,Russia
 GZQ,Zagros Air,ZAGROS,Iran
+HA1,Hankook Air US,,United States
 HAA,Helicopteros Agroforestal,AGROFORESTAL,Chile
 HAC,Henebury Aviation,,Australia
 HAD,Air d'Ayiti,HAITI AVIA,Haiti
+HAE,Kenmore Crew Leasing Inc,HOLLAND AIR,United States
 HAF,Hellenic Air Force,HELLENIC AIR FORCE,Greece
 HAG,Hageland Aviation Services,HAGELAND,United States
 HAH,Air Comores International,AIR COMORES,Comoros
@@ -2064,9 +2497,11 @@ HAX,Benair,SCOOP,Norway
 HAY,Hamburg Airways,HAMBURG AIRWAYS,Germany
 HBA,Trail Lake Flying Service,HARBOR AIR,United States
 HBC,Haitian Aviation Line,HALISA,Haiti
+HBH,Hebei Airlines,,China
 HBI,CHC Denmark,HELIBIRD,Denmark
 HBL,Faroecopter,HELIBLUE,Denmark
 HBN,Hibernian Airlines,,Ireland
+HBR,Hebradran Air Services,,United Kingdom
 HBT,Polizeihubschrauberstaffel Thüringen,HABICHT,Germany
 HBU,Universal Avia,KHARKIV UNIVERSAL,Ukraine
 HCA,Lake Havasu Air Service,HAVASU,United States
@@ -2074,34 +2509,48 @@ HCB,Helenair (Barbados),HELEN,Barbados
 HCC,Holidays Czech Airlines,CZECH HOLIDAYS,Czech Republic
 HCK,Heli-Charter,HELI-CHARTER,United Kingdom
 HCL,Helenair Corporation,HELENCORP,Saint Lucia
+HCN,Halcyon Air/Bissau Airways,,Guinea-Bissau
 HCP,Helicopter,HELI CZECH,Czech Republic
+HCT,CAT Helicopters SL,ROTORCAT,Spain
 HCV,Halcyonair,CREOLE,Cape Verde
+HCW,Star1 Airlines,,Lithuania
 HCY,Helios Airways,HELIOS,Cyprus
+HDA,Dragonair,,DRAGON
 HDC,Helcopteros De Cataluna,HELICATALUNA,Spain
 HDI,Hoteles Dinamicos,DINAMICOS,Mexico
+HDM,Harley-Davidson Motor Company Group LLC,HOG,United States
 HDR,Helikopterdrift,HELIDRIFT,Norway
 HEA,Heliavia-Transporte Aéreo,HELIAVIA,Portugal
 HEB,Heli Bernina,HELIBERNINA,Switzerland
 HEC,Heliservicio Campeche,HELICAMPECHE,Mexico
 HED,Heritage Aviation Developments,FLAPJACK,United Kingdom
+HEH,Helitrans AG,,Switzerland
 HEI,Aerohein,AEROHEIN,Chile
+HEJ,Hellas Jet,,Greece
 HEL,Helicol,HELICOL,Colombia
 HEM,CHC Helicopter,HEMS,Australia
 HEN,Helicópteros Y Vehículos Nacionales Aéreos,HELINAC,Mexico
-HER,Hex'Air,HEX AIRLINE,France
+HEP,Oslo Politidistrikt Helikoptertjenesten,HELIPOLICE,Norway
+HER,Hera Flight,,United States
+HES,Holiday Europe,HOLIDAY EUROPE,Bulgaria
 HET,TAF Helicopters,HELITAF,Spain
 HEX,Honiara Cargo Express,HONIARA CARGO,Solomon Islands
+HEY,Hellenic Airways,,Greece
 HEZ,Arrow Aviation,ARROW,Israel
 HFM,Hi Fly Malta,MOONRAKER,Malta
 HFR,Heli France,HELIFRANCE,France
 HFY,Hi Fly,SKY FLYER,Portugal
 HGA,Hogan Air,HOGAN AIR,United States
 HGD,Hangard Aviation,HANGARD,Mongolia
+HGE,Martins Famous Pastry Shoppe Inc,HOAGIE,United States
+HGG,Hi Air,HI AIR,South Korea
 HGH,Atlantic Air Lift,HIGHER,France
 HGK,Fika Salaama Airlines,SALAAMA,Uganda
 HGR,Hangar 8,HANG,United Kingdom
 HGT,GMJ Air Shuttle,HIGHTECH,United States
+HHA,Atlantic Airlines de Honduras,,Honduras
 HHE,Heli-Holland,HELI HOLLAND,Netherlands
+HHG,Hanergy Business Jets,HANERGY JET,China
 HHH,Helicsa,HELICSA,Spain
 HHI,Hamburg International,HAMBURG JET,Germany
 HHN,Hahn Air,ROOSTER,Germany
@@ -2130,6 +2579,7 @@ HKG,Government Flying Service,HONGKONG GOVERNMENT,Hong Kong SAR of China
 HKH,Air-Invest,HAWKHUNGARY,Hungary
 HKI,Hawkaire,HAWKEYE,United States
 HKL,Hak Air,HAK AIRLINE,Nigeria
+HKN,Jim Hankins Air Service,,United States
 HKR,Hawk Air,AIR HAW,Argentina
 HKS,CHC Helikopter Service,HELIBUS,Norway
 HKY,USAF Rammstein,,United States
@@ -2143,7 +2593,9 @@ HLG,Helog,HELOG,Switzerland
 HLH,Hala Air,HALA AIR,Sudan
 HLI,Heli Securite,HELI SAINT-TROPEZ,France
 HLK,Heli-Link,HELI-LINK,Switzerland
+HLL,Holiday Airlines Company,,Thailand
 HLM,Heli Medwest De Mexico,HELIMIDWEST,Mexico
+HLN,Air Holland,ORANGE,Netherlands
 HLO,Samaritan Air Service,HALO,Canada
 HLP,Helipistas,HELIPISTAS,Spain
 HLR,Heli Air Services,HELI BULGARIA,Bulgaria
@@ -2152,11 +2604,14 @@ HLT,Helitafe,HELITAFE,Mexico
 HLU,Heli Union Heli Prestations,HELI UNION,France
 HLW,Heliworks,HELIWORKS,Chile
 HLX,Hapag-Lloyd Express (TUIfly),YELLOW CAB,Germany
+HLY,Heli Air,WHISPER,United Kingdom
 HMA,Air Tahoma,TAHOMA,United States
+HMB,CHC Global Operations Canada,HUMMINGBIRD,Canada
 HMC,Heliamerica De Mexico,HELIAMERICA,Mexico
 HMD,Charlie Hammonds Flying Service,HAMMOND,United States
 HME,Babcock MCS,HELIMED,United Kingdom
 HMF,Norrlandsflyg,LIFEGUARD SWEDEN,Sweden
+HMJ,Harmony Jets,HARMONG JETS,Malta
 HMM,Hamra Air,HAMRA,United Arab Emirates
 HMP,Papair Terminal,PAPAIR TERMINAL,Haiti
 HMR,North American Charters,HAMMER,Canada
@@ -2166,42 +2621,53 @@ HMV,Homac Aviation,HOMAC,Luxembourg
 HMX,Hawk De Mexico,HAWK MEXICO,Mexico
 HMY,Harmony Airways,HARMONY,Canada
 HNA,Greek Navy,HELLENIC NAVY,Greece
+HND,Hinterland Aviation,HINTERLAND,AU
 HNL,CHC Helicopters Netherlands,MAPLELEAF,Netherlands
 HNR,Haiti National Airlines (HANA),HANAIR,Haiti
 HNT,Helicopteros Internacionales,HELICOP INTER,Mexico
+HNX,Hankook Airline,,South Korea
 HOA,Hola Airlines,HOLA,Spain
+HOB,HL Aircraft LLC,HOBBY JET,United States
 HOG,Mahogany Air Charters,HOGAN AIR,Zambia
 HOL,Holiday Airlines (US Airline),HOLIDAY,United States
 HOM,Aero Homex,AERO HOMEX,Mexico
+HON,Honda,HONDA TEST,United States
 HOP,Hop!,AIR HOP,France
 HOR,Horizon Air-Taxi,HORIZON,Switzerland
 HOZ,Horizontes Aéreos,HORIZONTES AEREOS,Mexico
 HPA,Pearl Airways,PEARL AIRWAYS,Haiti
 HPJ,Hop-A-Jet,HOPA-JET,United States
+HPK,Hopscotch Air Inc,HOPSCOTCH AIR,United States
 HPL,Heliportugal,HELIPORTUGAL,Portugal
 HPO,Almiron Aviation,ALMIRON,Uganda
 HPR,Rick Lucas Helicopters,HELIPRO,New Zealand
 HPS,Horizon Plus,HORIZON PLUS,Bangladesh
+HPY,Happy Air,,Thailand
 HQO,Avinor,,Norway
 HRA,Heli-Iberica,ERICA,Spain
 HRB,Haiti International Airline,HAITI AIRLINE,Haiti
+HRC,Harco Aviation,HARCO,United States
+HRE,FFH Sudwestdeutsche Verkehrsfliegerschule,HART AIR,Germany
 HRH,Royal Tongan Airlines,TONGA ROYAL,Tonga
 HRI,Skyraidybos Mokymo Centras,HELIRIM,Lithuania
+HRM,Hermes Airlines,,Greece
 HRN,Heron Luftfahrt,HERONAIR,Germany
 HRS,Pursuit Aviation,HORSEMAN,United States
 HRT,Chartright Air,CHARTRIGHT,Canada
 HRZ,Croatian Air Force,CROATIAN AIRFORCE,Croatia
 HSA,East African Safari Air,DUMA,Kenya
 HSE,Compania Helicopteros Del Sureste,HELISURESTE,Spain
+HSG,Hesnes Air AS,,NO
 HSH,Hispánica de Aviación,HASA,Spain
 HSI,Heliswiss,HELISWISS,Switzerland
 HSK,Sky Europe Airlines,MATRA,Slovakia
 HSM,Horizon Air for Transport and Training,ALOFUKAIR,Libya
-HSN,H.S.AVIATION CO., LTD.,H.S.AVIATION,Thailand
+HSN,H.S.AVIATION CO. LTD.,H.S.AVIATION,Thailand
 HSO,Campania Helicopteros De Transporte,HELIASTURIAS,Spain
 HSP,International Jet Charter,HOSPITAL,United States
 HSR,Citylink Airlines,HOOSIER,United States
 HSS,Compañía Transportes Aéreos Del Sur,TAS HELICOPTEROS,Spain
+HST,Hellenic Star Airways,,Greece
 HSU,Helisul,HELIS,Portugal
 HSV,Svenska Direktflyg,HIGHSWEDE,Sweden
 HSY,Sky Helicopteros,HELISKY,Spain
@@ -2210,8 +2676,10 @@ HTB,Helix-Craft Aviation,HELIX-CRAFT,Panama
 HTC,Haiti Trans Air,HAITI TRANSAIR,Haiti
 HTE,Midwest Helicopters De Mexico,HELICOPTERSMEXICO,Mexico
 HTG,Grossmann Air Service,GROSSMANN,Austria
+HTH,Helitt Líneas Aéreas,,Spain
 HTI,Haiti International Air,HAITI INTERNATIONAL,Haiti
 HTL,My Fair Jet,HOTLINE,Austria
+HTM,HTM - Helicopter Travel Munich GmbH,HELITRAVEL,Germany
 HTN,Haiti North Airline,,Haiti
 HTO,Tango Bravo,HELI TANGO,France
 HTP,Heli Trip,HELI TRIP,Mexico
@@ -2235,25 +2703,35 @@ HVN,Vietnam Airlines,VIET NAM AIRLINES,Vietnam
 HVY,Heavylift Cargo Airlines,HEAVY CARGO,Australia
 HWA,Hillwood Airways,Hillwood,United States
 HWD,HPM Investments,FLITEWISE,United Kingdom
+HWK,Firehawk Helicopters,FIREHAWK,United States
 HWY,Highland Airways,HIWAY,United Kingdom
 HXA,China Express Airlines,CHINA EXPRESS,China
 HYA,Hyack Air,HYACK,Canada
 HYC,Hydro Air Flight Operations,HYDRO CARGO,South Africa
 HYD,Hydro-Québec,HYDRO,Canada
 HYH,Heli Hungary,HELIHUNGARY,Hungary
+HYM,Himalayan Airlines,,Nepal
 HYP,Hyperion Aviation,HYPERION,Malta
 HYR,Airlink Airways,HIGHFLYER,Ireland
+HYS,HiSky Europe,SKY EUROPE,Romania
+HYT,YTO Cargo Airlines,QUICK AIR,China
+HZA,Horizon Airlines,,Australia
+HZL,Hazelton Airlines,,Australia
 HZT,Air Horizon,HORIZON TOGO,Togo
 HZX,Citic General Aviation,ZHONGXIN,China
 IAA,Indonesian Airlines,INDO LINES,Indonesia
 IAC,Interaviation Charter,INTERCHARTER,Romania
 IAD,AirAsia India,ARIYA,India
+IAE,AC Insat-Aero,,Russia
 IAF,Israeli Air Force,,Israel
 IAG,EPAG,EPAG,France
 IAI,Israel Aircraft Industries,ISRAEL AIRCRAFT,Israel
 IAJ,Islandair Jersey,JARLAND,United Kingdom
 IAK,International Air Cargo Corporation,AIR CARGO EGYPT,Egypt
+IAM,Aeronautica Militare,,Italy
+IAN,Ibom Air,IBOM,NG
 IAR,Iliamna Air Taxi,ILIAMNA AIR,United States
+IAS,International Air Service,,United States
 IAW,Iraqi Airways,IRAQI,Iraq
 IAX,International Air Services,INTERAIR SERVICES,Liberia
 IAY,Deadalos Flugtbetriebs,IASON,Austria
@@ -2261,6 +2739,7 @@ IBB,Binter Canarias,BINTER,Spain
 IBC,Ibicenca Air,IBICENCA,Spain
 IBE,Iberia Airlines,IBERIA,Spain
 IBG,Springfield Air,ICE BRIDGE,United States
+IBJ,Air Taxi & Charter International SA,IBERTAXI,Spain
 IBK,Norwegian Air International (Norway),NORTRANS,Norway
 IBL,IBL Aviation,CATOVAIR,Mauritius
 IBR,Ibertour Servicios Aéreos,IBERTOUR,Spain
@@ -2271,10 +2750,11 @@ IBX,Ibex Airlines,IBEX,Japan
 IBY,International Business Aircraft,CENTRAL STAGE,United States
 IBZ,International Business Air,INTERBIZ,Sweden
 ICA,Icaro,ICARFLY,Italy
-#ICAO,Airline,Call sign,Country/Region
 ICB,Icebird Airline,ICEBIRD,Iceland
 ICC,Institut Cartogràfic de Catalunya,CARTO,Spain
+ICD,Icaro,,Ecuador
 ICE,Icelandair,ICEAIR,Iceland
+ICF,ICS Aero SM SRL,INCHARTER,SM
 ICG,Icelandic Coast Guard,ICELAND COAST,Iceland
 ICJ,Icejet,ICEJET,Iceland
 ICL,CAL Cargo Air Lines,CAL,Israel
@@ -2284,32 +2764,47 @@ ICP,Intercopters,CHOPER,Spain
 ICR,Eagle Aero,ICARUS FLIGHTS,United States
 ICS,International Charter Services,INTERSERVI,Mexico
 ICT,Intercontinental de Aviación,CONTAVIA,Colombia
+ICU,Reignwood Asia Aviation Co Ltd,ASIA MEDICAL,China
 ICV,Cargolux Italia,CARGO MED,Italy
+ICX,International Charter Xpress,,United States
+ICY,Intercity Air,INTERCITY,Malaysia
 IDA,Indonesia Air Transport,INTRA,Indonesia
+IDE,Independence Air,,United States
 IDG,IDG Technology Air,INDIGO,Czech Republic
 IDL,Ildefonso Redriguez,ILDEFONSO,Mexico
 IDP,Independent Air Freighters,INDEPENDENT,Australia
 IDR,Indicator Company,INDICATOR,Hungary
+IDS,Indonesia Sky,,Indonesia
+IDX,Indonesa Air Aisa X,,Indonesia
+IEA,Inter European Airways,,United Kingdom
+IEI,Italian Army,ITALIAN ARMY,Italy
 IEP,Elipiu',ELIPIU,Italy
 IFA,FAI Air Service,RED ANGEL,Germany
 IFC,Indian Air Force,INDIAN AIRFORCE,India
 IFF,Interfreight Forwarding,INTERFREIGHT,Sudan
+IFG,Infinity Flight Group,INFINITY,United States
 IFI,Air Lift,HELLAS LIFT,Greece
 IFL,IFL Group,EIFEL,United States
 IFM,Ifly,ICOPTER,Greece
 IFS,Italy First,RIVIERA,Italy
 IFT,Interflight,INTERFLIGHT,United Kingdom
 IFX,International Flight Training Academy,IFTA,United States
+IG1,Indya Airline Group,,India
 IGA,Skytaxi,IGUANA,Poland
+IGC,Iraq Gate,,Iraq
 IGN,Interguide Air,DIVINE AIR,Nigeria
 IGO,IndiGo Airlines,IFLY,India
 IGS,Isle Grande Flying School,ISLA GRANDE,United States
+IHC,Iran Helicopter Company,HELIRAN,Iran
 IHE,Interjet Helicopters,INTERCOPTER,Greece
+IHO,748 Air Services,SEFEAS,Kenya
 IHS,Thryluthjonustan,,Iceland
+IIA,AIR INDOCHINE,,Vietnam
 IIC,Inter Island Air Charter,,Bahamas
-IIG,International Company for Transport, Trade and Public Works,ALDAWLYH AIR,Libya
+IIG,International Company for Transport Trade and Public Works,ALDAWLYH AIR,Libya
 IIL,India International Airways,INDIA INTER,India
 IIN,Inter Island Airways,,Cape Verde
+IIR,INAVIA Internacional,,Argentina
 IJA,International Jet Aviation Services,I-JET,United States
 IJE,Ivoire Jet Express,IVOIRE JET,Ivory Coast
 IJM,IJM International Jet Management,JET MANAGEMENT,Austria
@@ -2330,20 +2825,27 @@ ILN,Interair South Africa,INLINE,South Africa
 ILP,Ilpo Aruba Cargo,,Aruba
 ILS,Servicios Aéreos Ilsa,SERVICIOS ILSA,Mexico
 ILV,Il-Avia,ILAVIA,Russia
+ILW,Illinois Airways,,United States
+ILY,Fly Illi,,United States
 IMA,Inter-Mountain Airways,INTER-MOUNTAIN,United States
 IME,Airtime Charters,AIRTIME,United Kingdom
 IMG,Imperial Cargo Airlines,IMPERIAL AIRLINES,Ghana
 IMN,Aerotaxis Cimarron,TAXI CIMARRON,Mexico
+IMP,Hellenic Imperial Airways,,Greece
 IMR,Imaer,IMAER,Portugal
 IMT,Imtrec Aviation,IMTREC,Cambodia
 IMX,Zimex Aviation,ZIMEX,Switzerland
 INA,Aero Internacional,AERO-NACIONAL,Mexico
 INC,Insel Air International,INSELAIR,Netherlands Antilles
 IND,Iona National Airways,IONA,Ireland
+INE,International Europe,,Spain
+ING,Aeroingenieria,,Chile
+INI,Initium Aviation,INITIUM,Spain
 INK,Sincom-Avia,SINCOM AVIA,Ukraine
 INL,Intal Avia,INTAL AVIA,Kyrgyzstan
 INO,Aeroservicios Intergrados de Norte,INTENOR,Mexico
 INP,Peruvian Navy,,Peru
+INR,Babcock MCS Espana,INAER HELICOPTEROS,Spain
 INS,Inflite The Jet Centre,,United Kingdom
 INT,Intair,INTAIRCO,Canada
 INU,Flyguppdraget Backamo,INSTRUCTOR,Sweden
@@ -2358,6 +2860,7 @@ IPM,IPM Europe,SHIPEX,United Kingdom
 IPN,Industri Pesawat Terbang Nusantara,NUSANTARA,Indonesia
 IPR,Independent Carrier (ICAR),ICAR,Ukraine
 IPT,Interport Corporation,INTERPORT,United States
+IPV,Parmiss Airlines (IPV),,Iran
 IQQ,Caribbean Airways,CARIBJET,Barbados
 IRA,Iran Air,IRANAIR,Iran
 IRB,Iranair Tours,,Iran
@@ -2374,7 +2877,9 @@ IRL,Irish Air Corps,IRISH,Ireland
 IRM,Mahan Air,MAHAN AIR,Iran
 IRO,CSA Air,IRON AIR,United States
 IRP,Payam Air,PAYAMAIR,Iran
+IRQ,Qeshm Air,,Iran
 IRR,Tara Air Line,TARAIR,Iran
+IRT,Irtysh Airlines,,Uzbekistan
 IRU,Chabahar Airlines,CHABAHAR,Iran
 IRV,Safat Airlines,SAFAT AIR,Iran
 IRW,Aram Airline,ARAM,Iran
@@ -2382,6 +2887,7 @@ IRX,Aria Tour,ARIA,Iran
 IRY,Eram Air,ERAM AIR,Iran
 IRZ,Saha Airlines Services,SAHA,Iran
 ISA,Island Airlines,,United States
+ISC,Isles of Scilly Skybus,,United Kingdom
 ISD,ISD Avia,ISDAVIA,Ukraine
 ISF,International Stabilisation Assistance Force,,United Kingdom
 ISG,Club Air,CLUBAIR,Italy
@@ -2395,6 +2901,7 @@ ISS,Meridiana,MERIDIANA,Italy
 IST,Istanbul Airlines,ISTANBUL,Turkey
 ISV,Islena De Inversiones,,Honduras
 ISW,Islas Airways,PINTADERA,Spain
+ISX,Island Spirit,,Iceland
 ITA,Inter-Air,CAFEX,United States
 ITC,International Air Carrier Association,,Belgium
 ITE,Aerotaxi S.R.O.,AEROTAXI,Czech Republic
@@ -2410,6 +2917,7 @@ ITS,Inter-State Aviation,INTER-STATE,United States
 ITU,Intervuelos,INTERLOS,Mexico
 ITW,Inter Air,INTER WINGS,Bulgaria
 ITX,Imair Airlines,IMPROTEX,Azerbaijan
+ITY,ITA Airways,ITARROW,Italy
 IUS,Icarus,ICARUS,Italy
 IVA,Innotech Aviation,INNOTECH,Canada
 IVE,Air Executive,COMPANY EXEC,Spain
@@ -2418,78 +2926,203 @@ IVR,Burundaiavia,RERUN,Kazakhstan
 IVS,Ivoire Aero Services,IVOIRE AERO,Ivory Coast
 IVT,Interaviatrans,INTERAVIA,Ukraine
 IVW,Ivoire Airways,IVOIRAIRWAYS,Ivory Coast
+IVY,Ivory Coast Air Force,,CI
+IWA,Apache Air,,United States
 IWD,Iberworld,IBERWORLD,Spain
 IWL,Island Wings,,Bahamas
 IWS,Aviainvest,,Russia
 IWY,InterCaribbean Airways,ISLANDWAYS,Turks and Caicos Islands
+IXO,OCEAN AIR CARGO,,India
 IXR,Ixair,X-BIRD,France
 IXX,Dolphin Express Airlines,ISLAND EXPRESS,United States
 IYE,Yemenia,YEMENI,Yemen
 IZA,Izhavia,IZHAVIA,Russia
 IZG,Zagros Airlines,ZAGROS,Iran
 IZM,Izair,IZMIR,Turkey
+J88,Regionalia México,,Mexico
+JAA,Japan Asia Airways,,Japan
 JAB,Air Bagan,AIR BAGAN,Myanmar
+JAC,Japan Air Commuter,,Japan
 JAD,Aerojal,AEROJAL,Mexico
+JAE,Jade Cargo International,,China
+JAF,TUI fly Belgium,BEAUTY,Belgium
+JAG,Jetalliance,,Austria
+JAI,Jet Airways,,India
+JAK,Jana-Arka,,Kazakhstan
 JAL,Japan Airlines,,Japan
 JAM,Sunline Express,SUNTRACK,Kenya
 JAR,Airlink,AIRLINK,Austria
 JAS,Jet Aviation Flight Services,,United States
+JAT,Jat Airways,,Serbia
+JAV,Jordan Aviation,,Jordan
+JAW,Jamahiriya Airways,,Libya
+JAX,Janair,,United States
+JAZ,JALways,,Japan
 JBA,Helijet,HELIJET,Canada
+JBC,Jetbee,JETBEE,Czech Republic
+JBE,Sino Jet Co Ltd,SINO BEIJING,China
+JBR,Job Air,,Czech Republic
 JBU,Jet Blue,JETBLUE,United States
+JBW,Jubba Airways,AIRJUB,Kenya
 JCB,J C Bamford,,United Kingdom
+JCC,Jetcraft Aviation,,Australia
+JCF,Jet Center Flight Training,,Spain
 JCH,Trading Air Cargo,TRADING CARGO,Mauritania
+JCI,Jordan International Air Cargo,,Jordan
+JCK,Jackson Air Services,,Canada
+JCL,Jetcall,JETCALL,Germany
 JCM,Secure Air Charter,SECUREAIR,United States
+JCO,Jet Concierge Club,CONCIERGE,GB
 JCR,Rotterdam Jet Center,ROTTERDAM JETCENTER,Netherlands
+JCS,Jetclub,,Switzerland
+JCT,Jet Charter,,United States
+JCX,Jet Connection,,Germany
 JCY,Jet City,JETCITY,United States
+JDA,JDAviation,,United Kingdom
 JDC,Deere and Company,JOHN DEERE,United States
+JDG,Joanas Avialinijos,,Lithuania
 JDI,Blue Jet,JEDI,Poland
+JDP,JDP Lux,,Luxembourg
+JEA,Jet Air,,Poland
+JEC,Jett8 Airlines Cargo,,Singapore
+JED,Jet East International,,United States
 JEE,Ambjek Air Services,AMBJEK AIR,Nigeria
 JEF,JetFlite,,Finland
+JEI,Jet Executive International Charter,,Germany
+JEJ,Jets Ejecutivos,,Mexico
+JEK,Jet Link,,Israel
 JEL,Tal Air Charters,JETEL,Canada
 JEM,Emerald Airways,GEMSTONE,United Kingdom
+JEP,Jets Personales,,Spain
+JES,JS Aviation,,Mexico
 JET,Wind Jet,GHIBLI,Italy
 JEV,Lagun Air,,Spain
+JEX,JAL Express,,Japan
 JFA,JetFly Aviation,JETFLY,Luxembourg
 JFC,LTV Jet Fleet Corporation,JET-FLEET,United States
 JFK,Keenair Charter -,KEENAIR,United Kingdom
+JFL,Jetfly Airlines,,Austria
+JFS,Juanda Flying School,,Indonesia
+JFU,Jet4You,,Morocco
 JFY,Foster Yeoman,YEOMAN,United Kingdom
+JGD,Jet G&D Aviation,,Israel
+JGN,Jagson Airlines,,India
+JGO,JetsGo,,Canada
+JHM,JHM Cargo Expreso,,Costa Rica
+JHN,Johnson Air,,United States
 JIA,PSA Airlines,BLUE STREAK,United States
+JIB,Jibair,,Djibouti
+JIC,Jetgo International,,Thailand
 JIM,Sark International Airways,SARK,United Kingdom
 JIT,Jet It,,United States
+JIV,Jivair AB,JIV AIR,Sweden
+JJA,Jeju Air,,Republic of Korea
 JJM,Regional Geodata Air,GEODATA,Spain
+JJP,Jetstar Japan ,,Japan
 JKA,LeTourneau University,JACKET,United States
+JKH,JK JetKontor AG,JETKONTOR,Germany
+JKK,Spanair,,Spain
 JKR,Justice Air,JOKER,United States
 JKY,Helicopter & Aviation Services,JOCKEY,United Kingdom
 JLA,MIA Airlines,SALLINE,Romania
+JLB,Jhonlin Air Transport,JHONLIN,Indonesia
+JLG,Jet Logistics Inc,LOGISTICS,United States
 JLH,Centro de Servicio Aeronautico,CESA,Mexico
 JLJ,Noble Air Charter,,
 JLN,Eurojet Limited,JET LINE,Malta
+JLX,Jetlink Express,,Kenya
+JMB,Jambo Africa Airlines,,Democratic Republic of Congo
+JMC,JMC Airlines,,United Kingdom
+JME,Executive Jet Management Europe,JETMAN,GB
+JMG,JetMagic,,Ireland
+JMJ,Johnston Airways,,United States
+JML,Jet Aviation Flight Services Ltd,MALTA JET,Malta
+JMM,Joint Military Commission,,Sudan
 JMP,Businesswings,JUMP RUN,Germany
 JMR,Alexandair,ALEXANDAIR,Canada
+JMS,Arc en Ciel Aviation,SKY AVIATION,Senegal
+JMT,Jomartaxi Aereo,,Mexico
 JMX,Air Jamaica Express,JAMAICA EXPRESS,Jamaica
 JNA,Jin Air,JIN AIR,South Korea
 JNH,M & N Aviation,JONAH,United States
+JNL,JetNetherlands,JETNETHERLANDS,Netherlands
+JNR,Jet Norte,,Mexico
+JNV,Jetnova de Aviacion Ejecutiva,,Spain
+JNY,Jenney Beechcraft,,United States
 JOA,Air Swift Aviation,,Australia
 JOB,Aerojobeni,JOBENI,Mexico
+JOC,Just Us Air,,Romania
 JOL,Atyrau Air Ways,EDIL,Kazakhstan
+JON,Johnsons Air,,Ghana
+JOR,Blue Air,,Romania
 JOS,DHL de Guatemala,,Guatemala
+JOY,Joy Air,,China
 JPA,OSACOM,J-PAT,United States
+JPJ,Jupiter Jet,JUPITERJET,Kazakhstan
+JPL,JetsPlus,SEQUOIA,United States
+JPN,Jeppesen UK,,United Kingdom
+JPO,Jetpro,,Mexico
+JPQ,Jett Paqueteria,,Mexico
 JPR,Aerosmith Aviation,JASPER,United States
+JPU,Jupiter Airlines,,United Arab Emirates
+JPV,Jet Pool Network,JETPOOL,Austria
+JRB,Jc royal.britannica,,United Kingdom
+JRC,JetAir Caribbean,JETAIR,Aruba
 JRF,First Air Transport,,Japan
+JRI,Jetrider International,,United Kingdom
+JRN,Jet Rent,,Mexico
+JRT,JetRight Charter,JETRIGHT,United States
+JSA,Jetstar Asia Airways,,Singapore
+JSE,Jets Y Servicios Ejecutivos,,Mexico
+JSH,Jetstream Air,,Hungary
+JSI,Jet Air Group,,Russia
+JSJ,JS Air,,Pakistan
+JSL,SelectJet,SELECTJET,United States
+JSM,Jet Stream,,Moldova
+JSN,Suncor Energy Inc,JETSUN,Canada
 JSP,Palmer Aviation,PALMER,United Kingdom
-JST,Eastern Australia Airlines,,Australia
+JSR,Jusur airways,,Egypt
+JST,Jetstar Airways,,Australia
+JSV,Japan Aircraft Service,,Japan
+JSW,Jigsaw Project,,United Kingdom
+JSX,JetSuiteX Air,BIGSTRIPE,United States
+JSY,Jung Sky D.o.o.,JUNG SKY,HR
+JTA,Japan Transocean Air,,Japan
+JTB,Jet Budget,,Sint Maarten
+JTC,Jet Trans Aviation,,Ghana
+JTD,Jet Time,NEW JET,Denmark
 JTE,National Jet Express,JETEX,Australia
+JTG,Jettime,,Denmark
 JTI,Cirrus Middle East,,Lebanon
-JTL,Jet Linx,JETLINX, United States
+JTL,Jet Linx,JETLINX,United States
 JTM,Exxavia Limited,SKYMAN,Ireland
+JTN,Jettrain Corporation,,United States
+JTO,Jettor Airlines,,Hong Kong
 JTR,Executive Aviation Services,JESTER,United Kingdom
 JTS,Arrendamiento de Aviones Jets,AVIONESJETS,Mexico
+JTT,Jet-2000,,Russia
 JTU,Zhetysu,ZHETYSU,Kazakhstan
+JTX,Jet Aspen Air Lines,,United States
+JTY,Jatayu Airlines,,Indonesia
+JTZ,Nicholas Air,STEEL JET,United States
 JUA,Aero Juarez,JUAREZ,Mexico
 JUB,Jubba Airways,,Kenya
+JUC,Juba Cargo Services & Aviation Company,,Sudan
 JUN,Royal Navy,,United Kingdom
+JUR,Ju-Air,,Switzerland
 JUS,USA Jet Airlines,JET USA,United States
+JVK,Jorvik,,Iceland
+JWW,JetWind,,United States
+JWX,Jetways Airlines,JETWAYS,Kenya
+JWY,Jetways of Iowa,,United States
+JXA,Jetex Aviation,,Lebanon
+JXT,Jetstream Executive Travel,,United Kingdom
+JXX,Jetx Airlines,,Iceland
+JYH,9 Air,TRANS JADE,China
+JYP,J & P Corporate Flights,CORP-FLIGHT,Mexico
 JZA,Air Canada Jazz,JAZZ,Canada
+JZR,Jazeera Airways,,Kuwait
+K88,Voestar,,Brazil
 KAA,Asia Aero Survey and Consulting Engineers,AASCO,Republic of Korea
 KAC,Kuwait Airways,KUWAITI,Kuwait
 KAD,Air Kirovograd,AIR KIROVOGRAD,Ukraine
@@ -2506,18 +3139,30 @@ KAS,Kingston Air Services,KINGSTON AIR,Canada
 KAT,Kato Airline,KATO-AIR,Norway
 KAV,Air Kufra,AIRKUFRA,Libya
 KAW,Kaz Air West,KAZWEST,Kazakhstan
+KAY,K5-Aviation,KAYAK,Germany
+KAZ,Comlux KZ,KAZLUX,Kazakhstan
 KBA,Kenn Borek Air,BOREK AIR,Canada
+KBD,Jetkey,JET KEY,France
 KBN,Spiracha Aviation,KABIN,Thailand
+KBR,KoralBlue Airlines,,Egypt
+KBS,Business Aero,,Russia
 KBV,Kustbevakningen,SWECOAST,Sweden
+KBX,Ibex-UL Sp ZOO,SKYBEX,Poland
+KBZ,Air KBZ,,Burma
 KCA,Trans-Kiev,TRANS-KIEV,Ukraine
 KCE,Irving Oil,KACEY,Canada
 KCH,KC International Airlines,CAM AIR,Cambodia
 KCR,Kolob Canyons Air Services,KOLOB,United States
+KCU,Skyline Ulasim Ticaret A.S.,,Turkey
+KDA,Kendell Airlines,,Australia
 KDC,K D Air Corporation,KAY DEE,Canada
 KDR,Royal Daisy Airlines,DARLINES,Uganda
+KDS,Makani Kai Air Charters,KALEO,United States
 KDY,Lyon Aviation,,United States
 KDZ,Flightworks,KUDZU,United States
+KEA,Korea Express Air,,South Korea
 KEE,Keystone Air Service,KEYSTONE,Canada
+KEJ,Kaz Air Jet,KAZAIRJET,Kazakhstan
 KEK,Arkhabay,ARKHABAY,Kazakhstan
 KEM,CemAir,CEMAIR,South Africa
 KEN,Kenmore Air,KENMORE,United States
@@ -2525,6 +3170,7 @@ KES,Kallat El Saker Air Company,KALLAT EL SKER,Libya
 KEW,Keewatin Air,BLIZZARD,Canada
 KEY,Key Airlines,KEY AIR,United States
 KFA,Kelowna Flightcraft Air Charter,FLIGHTCRAFT,Canada
+KFB,Superior Transportation Associates,MISSION,United States
 KFC,Kremenchuk Flight College,KREMENCHUK,Ukraine
 KFE,SkyFirst LTD,SKYFIRST,Malta
 KFK,Aero Charter Krifka,KRIFKA AIR,Austria
@@ -2536,15 +3182,20 @@ KGB,Kyrgz General Aviation,KEMIN,Kyrgyzstan
 KGC,Peach Air,GOLDCREST,United Kingdom
 KGD,Air Concorde,CONCORDE AIR,Bulgaria
 KGL,Kogalymavia Air Company,KOGALYM,Russia
+KGO,Korongo Airlines,,Congo (Kinshasa)
 KGT,Knights Airlines,KNIGHT-LINER,Nigeria
 KGZ,Kyrgyz Airlines,BERMET,Kyrgyzstan
+KHA,Kitty Hawk Aircargo,,United States
 KHB,Dalavia,DALAVIA,Russia
+KHC,Kitty Hawk Airways,,United States
 KHE,Kanfey Ha'emek Aviation,KANFEY HAEMEK,Israel
 KHH,Alexandria Airlines,,Egypt
 KHK,Kharkiv Airlines,SUNRAY,Ukraine
+KHM,Cambodia Airlines,,Cambodia
 KHO,Khors Aircompany,AIRCOMPANY KHORS,Ukraine
 KHP,Khoezestan Photros Air Lines,PHOTROS AIR,Iran
 KHR,Khazar,KHAZAR,Turkmenistan
+KHT,Khatlon Air,KHATLON,Tajikistan
 KHV,Angkor Air,AIR ANGKOR,Cambodia
 KHX,Knighthawk Express,RIZZ,United States
 KHY,Khyber Afghan Airlines,KHYBER,Afghanistan
@@ -2557,15 +3208,21 @@ KIP,Kinnarps,KINNARPS,Sweden
 KIS,Contactair,CONTACTAIR,Germany
 KIW,Royal New Zealand Air Force,KIWI,New Zealand
 KIZ,Kanaf-Arkia Airlines,,Israel
+KJC,Krasnojarsky Airlines,,Russia
+KJD,Algerian Air Force,ALGERIAN AIRFORCE,Algeria
+KJE,KapaJet,KAPAJET,Greece
 KKA,Kazavia,KAKAIR,Kazakhstan
 KKB,Air South,KHAKI BLUE,United States
 KKK,Atlasjet,ATLASJET,Turkey
 KKS,Salem,KOKSHE,Kazakhstan
+KLA,Air Lithuania,,Lithuania
 KLB,Air Mali International,TRANS MALI,Mali
 KLC,KLM Cityhopper,CITY,Netherlands
 KLD,Air Klaipėda,AIR KLAIPEDA,Lithuania
 KLE,Rusaero,,Russia
+KLG,Karlog Air Charter,,Denmark
 KLH,KLM Helicopter,KLM HELI,Netherlands
+KLJ,Klasjet,CLASS LINE,LT
 KLM,KLM,KLM,Netherlands
 KLO,Flight-Ops International,KLONDIKE,Canada
 KLR,Columbus Air Transport,KAY-LER,United States
@@ -2582,18 +3239,25 @@ KMI,K-Mile Air,KAY-MILE AIR,Thailand
 KMP,Kampuchea Airlines,KAMPUCHEA,Cambodia
 KMR,Western Pacific Airlines,KOMSTAR,United States
 KMV,Komiinteravia,KOMIINTER,Russia
+KMZ,Comores Aviation,COMORES AVIATION,KM
 KNA,Knight Air,KNIGHTAIR,Canada
+KND,Kan Air,,Thailand
+KNE,Nas Air,,Saudi Arabia
 KNG,King Aviation,KING,United Kingdom
 KNI,KD Avia,KALININGRAD AIR,Russia
 KNM,GB Helicopters,KINGDOM,United Kingdom
 KNS,Kinshasa Airways,KINSHASA AIRWAYS,Democratic Republic of the Congo
+KNT,Flightpath Charter Airways Inc,KINETIC,Canada
 KNX,Knighthawk Air Express,KNIGHT FLIGHT,Canada
 KOA,Koanda Avacion,KOANDA,Spain
 KOB,Koob-Corp - 96 KFT,AUTOFLEX,Hungary
+KOC,SetAir,SETAIR,Turkey
 KOE,Northland Aviation,KOKEE,United States
 KOK,Horizon Air Service,KOKO,United States
+KOL,SOCHI AIR,,Russia
 KOM,Kom Activity,COMJET,Netherlands
 KOP,Servicios Aéreos Copters,COPTERS,Chile
+KOQ,Kostromskie avialinii,,Russia
 KOR,Air Koryo,AIR KORYO,Democratic People's Republic of Korea
 KOS,Kosova Airlines,KOSOVA,Serbia
 KOV,Orlan-2000,ORLAN,Kazakhstan
@@ -2603,6 +3267,7 @@ KPA,Kunpeng Airlines,KUNPENG,China
 KPH,Kazan Helicopters,KAMA,Russia
 KPM,Sky Prim Air,SKY PRIMAIR,Molodva
 KPO,NXT Jet,,United States
+KPR,Trustco Air Services Ltd,SKIPPER,Namibia
 KQA,Kenya Airways,KENYA,Kenya
 KRA,Kiwi Regional Airlines,REGIONAL,New Zealand
 KRB,Karibu Airways Company,KARIBU AIR,Tanzania
@@ -2618,7 +3283,9 @@ KRO,Kroonk Air Agency,KROONK,Ukraine
 KRP,Carpatair,CARPATAIR,Romania
 KRS,Rosen Aviation,,Japan
 KRT,Air Kokshetau,KOKTA,Kazakhstan
+KRU,Karun Airlines,KARUN,IR
 KRV,Khoriv-Avia,KHORIV-AVIA,Ukraine
+KRY,Russkie Krylya,,Russia
 KSA,K S Avia,SKY CAMEL,Latvia
 KSI,Air Kissari,KISSARI,Angola
 KSM,Kosmos,KOSMOS,Russia
@@ -2626,33 +3293,47 @@ KSP,Servicios Aéreos Expecializados En Transportes Petroleros,SAEP,Colombia
 KSS,Raytheon Travel Air,KANSAS,United States
 KST,PTL Luftfahrtunternehmen,KING STAR,Germany
 KSU,Kansas State University,K-STATE,United States
+KSY,KSY,,Greece
+KSZ,Sunrise Airways,,Haiti
 KTA,Kirov Air Enterprise,VYATKA-AVIA,Russia
 KTB,Transaviabaltika,TRANSBALTIKA,Lithuania
 KTC,Kyrgyz Trans Avia,DINARA,Kyrgyzstan
 KTK,Katekavia,KATEKAVIA,Russia
 KTL,P & P Floss Pick Manufacturers,KNOTTSBERRY,South Africa
 KTN,Aeronavigaciya,AERONAVIGACIYA,Ukraine
+KTO,Aeroservicios Kratos SA De CV,KRATOS,Mexico
 KTR,HT Helikoptertransport,COPTER TRANS,Sweden
 KTS,Transair-Gyraintiee,KOTAIR,Russia
 KTV,Kata Transportation,KATAVIA,Sudan
 KUG,Govt of Kuwait,,Kuwait
+KUH,Kush Air,,South Sudan
+KUK,Kudlik Aviation Inc,KUDLIK,Canada
 KUS,National Airlines,KUSWAG,South Africa
+KUY,Kaz Air Trans,KAIGA,Kazakhstan
+KVA,Kavok Airlines,CATATUMBO,Venezuela
 KVK,Olimp Air,PONTA,Kazakhstan
 KVR,Alliance Avia,KAVAIR,Kazakhstan
 KVS,Kevis,KEVIS,Kazakhstan
 KVZ,Z-Aero Airlines,,Ukraine
+KW1,Wataniya Airways,,Kuwait
 KWA,Vozdushnaya Academy,VOZAIR,Kazakhstan
 KWN,Kwena Air,KWENA,South Africa
 KWX,Florida Aerocharter,KAY DUB,United States
+KWY,Key Air,,United States
+KYA,Alghanim,,United States
+KYB,Skybridge Airops,,Italy
 KYC,Av Atlantic,DOLPHIN,United States
 KYD,Sky Messaging,SKYAD,South Africa
 KYE,Sky Lease Cargo,SKY CUBE,United States
 KYM,Krym,CRIMEA AIR,Ukraine
 KYR,Sky Aeronautical Services,SKY AERONAUTICAL,Mexico
+KYV,Kibris T,,Turkey
 KZA,Kurzemes Avio,,Russia
 KZE,Euro-Asia Air International,KAZEUR,Kazakhstan
 KZH,Zhez Air,,Kazakhstan
+KZK,Air Kazakhstan,,Kazakhstan
 KZM,Phoebus Apolloa Zambia,CARZAM,Zambia
+KZN,Aviaservice,KAZANAIR,RU
 KZR,Air Astana,ASTANALINE,Kazakhstan
 KZS,Kazaviaspas,ASTANALINE,Kazakhstan
 KZU,Kuzu Airlines Cargo,KUZU CARGO,Turkey
@@ -2661,6 +3342,7 @@ LAA,Libyan Arab Airlines,LIBAIR,Libya
 LAB,L.A.B. Flying Service,LAB,United States
 LAC,Lockeed Aircraft Corporation,LOCKHEED,United States
 LAD,Lebanon Airport Development Corporation,LADCO-AIR,United States
+LAE,LATAM Cargo Colombia,,Colombia
 LAF,Latvian Air Force,LATVIAN AIRFORCE,Latvia
 LAG,Aviation Legacy,AVILEG,Gambia
 LAH,L A Helicopter,STAR SHIP,United States
@@ -2673,6 +3355,7 @@ LAO,Lao Airlines,LAO,Lao People's Democratic Republic
 LAP,LATAM Paraguay,PARAGUAYA,Paraguay
 LAQ,Lebanese Air Transport,LAT,Lebanon
 LAR,Lawrence Aviation,LAWRENCE,United States
+LAS,Skymedia,LIONS HELICOPTER,Switzerland
 LAT,Lebanese Air Transport (charter),LEBANESE AIR,Lebanon
 LAU,Líneas Aéreas Suramericanas,SURAMERICANO,Colombia
 LAV,AlbaStar,ALBASTAR,Spain
@@ -2682,6 +3365,7 @@ LAY,Layang-Layang Aerospace,LAYANG,Malaysia
 LBC,Albanian Airlines,ALBANIAN,Albania
 LBH,Laker Airways (Bahamas),LAKER BAHAMAS,United States
 LBI,Albisa,ALBISA,Mexico
+LBL,Line Blue,,Germany
 LBQ,Quest Diagnostics,LABQUEST,United States
 LBR,Elbe Air Transport,MOTION,Germany
 LBT,Nouvel Air Tunisie,NOUVELAIR,Tunisia
@@ -2691,6 +3375,7 @@ LBZ,Angkasa Super Service,,Indonesia
 LCA,Leconte Airlines,LECONTE,United States
 LCB,LC Busre,BUSRE,Peru
 LCC,The Lancair Company,LANCAIR,United States
+LCD,Lineas Aereas Azteca,,Mexico
 LCG,Lignes Aeriennes Congolaises,CONGOLAISE,Democratic Republic of the Congo
 LCH,Lynch Flying Service,LYNCH AIR,United States
 LCM,Líneas Aéreas Comerciales,LINEAS COMERCIALES,Mexico
@@ -2699,6 +3384,7 @@ LCO,LATAM Cargo Chile,LAN CARGO,Chile
 LCR,Libyan Arab Air Cargo,LIBAC,Libya
 LCS,RAF Leuchars,LEUCHARS,United Kingdom
 LCT,Compañía De Actividades Y Servicios De Aviación,STELLAIR,Spain
+LCV,SmartLynx Airlines Cabo Verde,CABO CAT,Cape Verde
 LCY,London City Airport Jet Centre,LONDON CITY,United Kingdom
 LDA,Lauda Air,LAUDA AIR,Austria
 LDE,LADE - Líneas Aéreas Del Estado,LADE,Argentina
@@ -2725,6 +3411,7 @@ LET,Aerolíneas Ejecutivas,MEXEJECUTIV,Mexico
 LEU,Lions-Air,LIONSAIR,Switzerland
 LEX,L'Express Airlines,LEX,United States
 LFA,Air Alfa,,Turkey
+LFC,Aero Control Air,,Canada
 LFE,Luxflight Executive,LUX EXPRESS,Luxembourg
 LFI,National Airways Corporation,AEROMED,South Africa
 LFL,Executive Air,LIFE FLIGHT,Zimbabwe
@@ -2740,42 +3427,58 @@ LGN,Aerolaguna,AEROLAGUNA,Mexico
 LGT,Longtail Aviation,LONGTAIL,Bermuda
 LGU,Servicios Aéreos Ejecutivos De La Laguna,LAGUNA,Mexico
 LGW,German Airways,WALTER,Germany
+LHA,Longhao Airlines,AIR CANTON,China
 LHB,Liebherr Geschaeftreiseflugzeug,FAMILY,Germany
 LHC,London Helicopter Centres,MUSTANG,United Kingdom
+LHK,Lahak Aviation Ltd,,IL
+LHN,Express One International,,United States
 LHR,Al Ahram Aviation,AL AHRAM,Egypt
 LHS,Luhansk,ENTERPRISE LUHANSK,Ukraine
 LHT,Lufthansa Technik,LUFTHANSA TECHNIK,Germany
 LIA,Leeward Islands Air Transport,LIAT,Antigua and Barbuda
 LIB,Polizeihubschrauberstaffel Hamburg,LIBELLE,Germany
+LIC,Asia Sky Lines,ASIASLINE,Tajikistan
 LID,Alidaunia,ALIDA,Italy
 LIE,Al-Dawood Air,AL-DAWOOD AIR,Nigeria
 LIF,Rocky Mountain Holdings,LIFECARE,United States
 LIJ,Líneas Aéreas San Jose,LINEAS JOSE,Mexico
+LIL,FlyLal,,Lithuania
 LIN,Aerolimousine,AEROLIMOUSINE,Russia
+LIO,LÍO Flugmennt,,Iceland
+LIP,Lipican Aer,LIPIZAN,SK
 LIQ,Lid Air,,Sweden
 LIR,Minsk Aircraft Overhaul Plant,LISLINE,Belarus
 LIS,Eastern Express,LARISA,Kazakhstan
+LIV,Air Livonia,,Estonia
+LIX,LionXpress,,Cameroon
+LIZ,Sky Jet,,Canada
 LJA,Air Jamahiriya Company,AIR JAMAHIRIYA,Libya
+LJB,Al Jaber Aviation,AL JABER,AE
 LJC,Exclusive Jet Charter,,United Kingdom
+LJJ,Luchsh Airlines ,,Russia
 LJY,L J Aviation,ELJAY,United States
 LKA,Lao Capricorn Air,NAKLAO,Lao People's Democratic Republic
 LKD,Lignes Aeriennes Du Tchad,LATCHAD,Chad
 LKE,Lucky Air,LUCKY AIR,China
+LKF,Aviation Advisor Inc,LAKEFRONT,United States
 LKL,Lakeland Aviation,LAKELAND,United States
 LKN,Lankair,Lankair,Sri Lanka
 LKP,American Aviation,LAKE POWELL,United States
 LKR,Laker Airways,LAKER,United States
 LKS,Airlink Solutions,AIRLIN,Spain
+LKV,Lukiaviatrans,,RU
 LKW,Top Sky International,TOPINTER,Indonesia
 LKY,Air Solutions,LUCKY,United States
 LLA,Servico Leo Lopex,LEO LOPOZ,Mexico
 LLB,Lloyd Aéreo Boliviano,LLOYDAEREO,Bolivia
+LLC,FlyLAL Charters,,Lithuania
 LLD,Lloyd Aviation,,Venezuela
 LLL,Lao Skyway,LAVIE,Lao People's Democratic Republic
 LLM,Yamal Airlines,YAMAL,Russia
 LLO,Operation Enduring Freedom,APOLLO,Canada
 LLR,Air India Regional,ALLIED,India
 LLS,Servicios Aéreos Estrella,SERVIESTRELLA,Mexico
+LLT,Classic Jet UAB,CLASSIC JET,LT
 LMA,Aerolima,AEROLIMA,Mexico
 LMC,Línea Aérea Mexicana de Carga,LINEAS DECARGA,Mexico
 LME,Lignes Mauritaniennes Air Express,LIMAIR EXPRESS,Mauritania
@@ -2783,6 +3486,7 @@ LMG,South African Air Force,SOUTH AFRICAN,South Africa
 LMJ,Masterjet,MASTERJET,Portugal
 LMK,Grantex Aviation,LANDMARK,United Kingdom
 LML,Alamia Air,ALAMIA AIR,Libya
+LMM,LCM AIRLINES,,Russia
 LMN,Líneas Aéreas Monarca,LINEAS MONARCA,Mexico
 LMO,Sky One Holdings as Privaira,SKY HOLDINGS,United States
 LMP,Air Plus Argentina,AIR FLIGHT,Argentina
@@ -2797,15 +3501,19 @@ LNA,Lnair Air Services,ELNAIR,Spain
 LNC,LAN Dominicana,LANCANA,Dominican Republic
 LNE,Aerolane,AEROLANE,Ecuador
 LNG,Lockheed Martin Aeronautics Company,LIGHTNING,United States
+LNH,Lanhsa Airlines,,Honduras
 LNI,Lion Air,LION INTER,Indonesia
 LNK,Airlink,LINK,South Africa
 LNP,Línea Aérea SAPSA,SAPSA,Chile
 LNT,Aerolíneas Internacionales,LINEAINT,Mexico
 LNX,London Executive Aviation,LONEX,United Kingdom
+LOC,Locair,,United States
 LOD,Malmoe Air Taxi,LOGIC,Sweden
 LOF,Trans States Airlines,WATERSKI,United States
 LOG,Loganair,LOGAN,United Kingdom
 LOK,Alok Air,ALOK AIR,Sudan
+LOL,Easy Charter,EASY CHARTER,GE
+LOO,LSM Airlines,,Russia
 LOP,RAF Linton-on-Ouse,LINTON ON OUSE,United Kingdom
 LOR,Leo-Air,LEO CHARTER,South Africa
 LOS,RAF Lossiemouth,LOSSIE,United Kingdom
@@ -2818,12 +3526,15 @@ LPD,UK Royal/HRH Duke of York,LEOPARD,United Kingdom
 LPE,LATAM Peru,LANPERU,Peru
 LPL,Lease-a-Plane International,LEASE-A-PLANE,United States
 LPN,Laoag International Airlines,LAOAG AIR,Philippines
+LPR,L,,Argentina
 LPV,Air Alps Aviation,ALPAV,Austria
 LRA,Little Red Air Service,LITTLE RED,Canada
 LRB,L R Airlines,LADY RACINE,Czech Republic
 LRC,LACSA,LACSA,Costa Rica
 LRD,Laredo Air,LAREDO AIR,United States
+LRK,Skyjet Aviation Services Ltd,SKYLARK,NG
 LRO,Alrosa-Avia,ALROSA,Russia
+LRQ,Luxembourg Air Ambulance,LUX RESCUE,Luxembourg
 LRR,Lorraine Aviation,LORRAINE,France
 LRS,Sansa,,Costa Rica
 LRT,Lincoln Airlines,,Australia
@@ -2831,7 +3542,9 @@ LRW,Al Rida Airways,AL RIDA,Mauritania
 LSA,LANSA,INTERNACIONAL,Dominican Republic
 LSC,Los Cedros Aviación,CEDROS,Chile
 LSE,Línea De Aeroservicios,,Chile
+LSI,Aliscargo Airlines,ALIS,Italy
 LSK,Aurela,AURELA,Lithuania
+LSM,Aerobusinessservice,,Russia
 LSP,Spectrum Aviation Incorporated,AIR TONY,United Kingdom
 LSR,Alsair,ALSAIR,France
 LSS,Lone Star Airlines,LONE STAR,United States
@@ -2843,6 +3556,7 @@ LTC,Charter Jets,LATCHARTER,Latvia
 LTD,Executive Express Aviation/JA Air Charter,LIGHT SPEED,United States
 LTE,LTE International Airways,FUN JET,Spain
 LTF,Lufttaxi Fluggesellschaft,Garfield,Germany
+LTG,LATAM Cargo Brazil,TAMCARGO,BR
 LTI,Aerotaxis Latinoamericanos,LATINO,Mexico
 LTL,Benin Littoral Airways,LITTORAL,Benin
 LTO,LTU Austria,BILLA TRANSPORT,Austria
@@ -2860,14 +3574,17 @@ LUV,Luxembourg Air Rescue,LUX RESCUE,Luxembourg
 LUZ,Luzair,LISBON JET,Portugal
 LVB,IRS Airlines,SILVERBIRD,Nigeria
 LVD,Luftfahrt-Vermietungs-Dienst,AIR SANTE,Austria
+LVG,Livingston,,Italy
 LVL,Level,LEVEL,Spain and France
 LVN,Aliven,ALIVEN,Italy
 LVR,Aviavilsa,AVIAVILSA,Lithuania
 LVT,La Valenciana Taxi Aéreo,TAXIVALENCIANA,Mexico
 LWA,Libyan Wings,LIBYAN WINGS,Libya
 LWD,Leisure Air,LEISURE WORLD,United States
+LWG,Luxwing Ltd,LUXWING,Malta
 LWL,Lowlevel,CUB DRIVER,Portugal
 LXA,Luxaviation,RED LION,Luxembourg
+LXC,CAE Aviation,LUXVAN,Luxembourg
 LXF,Lynx Air International,LYNX FLIGHT,United States
 LXG,Air Luxor GB,LUXOR GOLF,Guinea-Bissau
 LXJ,Bombardier Business Jet Solutions,FLEXJET,United States
@@ -2890,18 +3607,22 @@ LZF,Lease Fly,SKYLEASE,Portugal
 LZP,Air Ban,DOC AIR,Bulgaria
 LZR,Air Lazur,LAZUR BEE-GEE,Bulgaria
 LZT,Lanzarote Aerocargo,BARAKA,Spain
+M1F,Maryland Air,,United States
+M7A,All America AR,,Argentina
 MAA,MasAir,MAS CARGA,Mexico
 MAB,Millardair,MILLARDAIR,Canada
 MAC,Air Arabia Maroc,ARABIA MAROC,Morocco
 MAD,Maple Air Services,MAPLE AIR,Canada
 MAE,Mali Air,MALI AIREXPRESS,Austria
 MAF,Mission Aviation Fellowship,MISSI,Indonesia
+MAH,Malév,,Hungary
 MAI,Max Avia,MAX AVIA,Kyrgyzstan
 MAJ,Majestic Airlines,MAGIC AIR,United States
 MAK,MAT Macedonian Airlines,MAKAVIO,Macedonia
 MAL,Morningstar Air Express,MORNINGSTAR,Canada
 MAM,Aeródromo De La Mancha,AEROMAN,Spain
 MAN,Mannion Air Charter,MANNION,United States
+MAO,Mayo Clinic,MAYO,United States
 MAQ,Mac Aviation,MAC AVIATION,Spain
 MAR,March Helicopters,MARCH,United Kingdom
 MAS,Malaysia Airlines,MALAYSIAN,Malaysia
@@ -2918,11 +3639,14 @@ MBC,Airjet Exploracao Aerea de Carga,MABECO,Angola
 MBE,Martin-Baker,MARTIN,United Kingdom
 MBG,Zephyr Aviation,CHALGROVE,United Kingdom
 MBI,Mountain Bird,MOUNTAIN BIRD,United States
+MBK,Chrono Jet,MATBLACK,Canada
 MBL,First City Air,FIRST CITY,United Kingdom
 MBN,Zambian Airways,ZAMBIANA,Zambia
 MBO,Mobil Oil,MOBIL,Canada
 MBR,Brazilian Navy Aviation,BRAZILIAN NAVY,Brazil
 MBS,Mbach Air,MBACHI AIR,Malawi
+MBV,Aeriantur-M,,Moldova
+MCA,MCA Airlines,,Sweden
 MCB,Air Mercia,WESTMID,United Kingdom
 MCC,MCC Aviation,DISCOVERY,South Africa
 MCD,Air Medical,AIR MED,United Kingdom
@@ -2950,14 +3674,18 @@ MDF,Mediterranean Air Freight,MED-FREIGHT,Greece
 MDG,Air Madagascar,AIR MADAGASCAR,Madagascar
 MDH,Madina Air,MADINA AIR,Libya
 MDI,IAS Medical,,United Kingdom
+MDJ,Jetran Air,,Romania
 MDK,Air Wanganui Air Ambulance,,New Zealand
 MDL,Mandala Airlines,MANDALA,Indonesia
 MDM,Medavia,MEDAVIA,Malta
 MDN,Mudan Airlines,,Somali Republic
+MDO,Domenican Airlines,,Dominican Republic
+MDP,Medallion Air,,Romania
 MDR,Compania Mexicana De Aeroplanos,AEROPLANOS,Mexico
 MDS,McNeely Charter Services,MID-SOUTH,United States
 MDT,Sundt Air,MIDNIGHT,Norway
 MDV,Moldavian Airlines,MOLDAVIAN,Moldova
+MDW,Midway Airlines,,United States
 MDX,Aerosud Charter,MEDAIR,South Africa
 MDY,Mediterranean Airways,,Egypt
 MEA,Middle East Airlines,CEDAR JET,Lebanon
@@ -2970,18 +3698,22 @@ MEJ,Medjet International,MEDJET,United States
 MEK,Med-Trans of Florida,MED-TRANS,United States
 MEL,Mega Linhas Aéreas,MEGA AIR,Brazil
 MEM,Meridian Limited,MERIDIAN CHERRY,Ukraine
+MEN,Mena Aerospace,RAHAL,Bahrain
 MEP,Midwest Airlines,MIDEX,United States
 MER,Methow Aviation,METHOW,United States
 MES,Mesaba Airlines,MESABA,United States
 MET,Meteorological Research Flight,METMAN,United Kingdom
 MEX,Metro Express,EAGLE EXPRESS,United States
+MEY,Justair Scandinavia,,Sweden
 MFA,Martyn Fiddler Associates,SEAHORSE,United Kingdom
 MFB,Mountain Flyers 80,MOUNTAINHELI,Switzerland
 MFC,Moncton Flying Club,EAST WIND,Canada
+MFG,Fly Mid Africa,MID AFRICA,GM
 MFL,Aero McFly,MCFLY,Mexico
 MFR,Midline Air Freight,MIDLINE FREIGHT,United States
 MFS,Miller Flying Services,MILLER TIME,United States
 MFT,Multiflight,YORKAIR,
+MFY,Medifly S.A. de C.V.,MEDIFLY MEX,Mexico
 MFZ,Mofaz Air,MOFAZ AIR,Malaysia
 MGA,MG Aviación,MAG AVACION,Spain
 MGB,Coulson Flying Service,MOCKINGBIRD,United Kingdom
@@ -2994,6 +3726,7 @@ MGM,Transporte Aero MGM,AERO EMM-GEE-EMM,Mexico
 MGO,Punto Fa,MANGO,Spain
 MGR,Magna Air,MAGNA AIR,Austria
 MGS,Aeromagar,AEROMAGAR,Mexico
+MGT,Air Attack Technologies,MIGHTYVAN,FR
 MGX,Montenegro Airlines,MONTENEGRO,Montenegro
 MHA,Mountain High Aviation,MOUNTAIN HIGH,United States
 MHC,Aero Jomacha,AERO JOMACHA,Mexico
@@ -3001,6 +3734,7 @@ MHD,Yas Air Kish,YAS AIR,Iran
 MHF,Maritime Helicopters,AIR MARITIME,United States
 MHL,Meridian Airlines,HASSIMAIR,Nigeria
 MHN,Manhattan Air,MANHATTAN,United Kingdom
+MHO,Mokulele Airlines,MAHALO,United States
 MHQ,Skargardshavets Helikoptertjanst,HELICARE,Finland
 MHS,Air Memphis,AIR MEMPHIS,Egypt
 MHU,Air Memphis,MEPHIS UGANDA,Uganda
@@ -3012,22 +3746,34 @@ MIE,Aero Premier De Mexico,AEROPREMIER,Mexico
 MIF,Miras,MIRAS,Kazakhstan
 MIG,Russian Aircraft Corporation-MiG,MIG AVIA,Russia
 MIM,Mimino,MIMINO,Russia
+MIN,MJets,,TH
 MIR,Miramichi Air Service,MIRAMICHI,Canada
 MIS,Midstate Airlines,MIDSTATE,United States
 MIT,Flight Line,MATCO,United States
 MIZ,Desarrollo Milaz,MILAZ,Mexico
 MJB,Magic Blue Airlines,MAGIC BLUE,Netherlands
 MJC,Mandarin Air,AIR MANDA,China
+MJE,Empire Aviation Group FZCO,EMJET,AE
+MJF,MJet,EM-EXPRESS,AT
+MJG,Michael Airlines,,Puerto Rico
+MJL,Jet Line International,,Moldova
 MJM,Eti 2000,ELCO ETI,Italy
 MJN,Royal Air Force of Oman,MAJAN,Oman
+MJP,Air Majoro,,Peru
 MJR,Midamerica Jet,MAJOR,United States
 MJT,Mex-Jet,MEJETS,Mexico
+MJX,Euroline,,Georgia
 MKA,MK Airline,KRUGER-AIR,Ghana
+MKD,MAT Airways,,Macedonia
+MKG,Air Mekong,,Vietnam
 MKH,Air Marrakech Service,AIR MARRAKECH,Morocco
 MKK,Malaya Aviatsia Dona,AEROKEY,Russia
 MKL,McCall Aviation,MCCALL,United States
+MKN,Mekong Airlines,,Cambodia
 MKO,Markoss Aviation,GOSHAWK,United Kingdom
+MKR,Lanmei Airlines,AIR LANME,China
 MKS,Pimichikamac Air,MIKISEW,Canada
+MKU,Island Air (WP),,United States
 MKY,Monky Aerotaxis,MONKY,Mexico
 MLA,40-Mile Air,MILE-AIR,United States
 MLB,Manaf International Airways,MANAF,Burundi
@@ -3037,8 +3783,10 @@ MLE,Moldaeroservice,MOLDAERO,Moldova
 MLF,Amal Airlines,AMAL,Djibouti
 MLG,Malagasy Airlines,,Madagascar
 MLH,Mahalo Air,MAHALO,United States
+MLI,Air Mali,,Mali
 MLK,Millennium Air,NIGERJET,Nigeria
 MLL,Aeroclub de Mallorca,MALLORCA,Spain
+MLM,Comlux Aviation Malta,LUXMALTA,Malta
 MLN,Air Madeleine,AIR MADELEINE,Canada
 MLO,Servicios Aéreos Milenio,MILENIO,Mexico
 MLR,Mihin Lanka,MIHIN LANKA,Sri Lanka
@@ -3050,12 +3798,15 @@ MLX,Malawi Express,MALAWI EXPRESS,Malawi
 MMA,Myanmar Airways International,MYANMAR,Myanmar
 MMC,Aermarche,AERMARCHE,Italy
 MMD,Air Alsie,MERMAID,Denmark
+MMF,Netherlands Air Force,,Netherlands
 MMG,Aereo Ruta Maya,RUTA MAYA,Guatemala
 MMH,McMahon Helicopter,NIGHT RIDER,United States
+MMI,Marina Militare Italiana,ITALIAN NAVY,Italy
 MMJ,Macau Jet International,MACAUJET,China
 MML,Hunnu Air,TRANS MONGOLIA,Mongolia
 MMM,Aviation Company Meridian,AVIAMERIDIAN,Russia
 MMN,Pro Airways,,United States
+MMO,Malta MedAir,MALIT,Malta
 MMP,AMP Incorporated,AMP-INC,United States
 MMR,Musrata Air Transport,MUSRATA AIR,Libya
 MMS,SAAD (A320) Limited,MUSAAD AIR,Cayman Islands
@@ -3071,6 +3822,7 @@ MNI,Aeromilenio,AEROMIL,Mexico
 MNJ,Menajet,MENAJET,Lebanon
 MNL,Miniliner,MINILINER,Italy
 MNO,Mango,TULCA,South Africa
+MNP,Spirit of Manila Airlines,,Philippines
 MNR,Mann Air,TEEMOL,United Kingdom
 MNS,Ministic Air,MINISTIC,Canada
 MNT,Montserrat Airways,MONTSERRAT,Montserrat
@@ -3081,11 +3833,13 @@ MNY,Mooney Aircraft Corporation,MOONEY FLIGHT,United States
 MNZ,Murmansk Aircompany,MURMAN AIR,Russia
 MOC,Air Monarch Cargo,MONARCH CARGO,Mexico
 MOH,Tigerfly,MOTH,United Kingdom
+MON,Monarch Airlines,,United Kingdom
 MOP,Aeropublicitaria De Angola,PUBLICITARIA,Angola
 MOR,Aerolíneas De Morelia,AEROMORELIA,Mexico
 MOS,Misr Overseas Airways,,Egypt
 MOV,VIM Airlines,MOV AIR,Russia
 MOW,Mohawk Airlines,MOHAWK AIR,United States
+MOZ,SalzburgJetAviation GmbH,MOZART,AT
 MPA,Mid-Pacific Airlines,MID PAC,United States
 MPC,Mountain Pacific Air,MOUNTAIN PACIFIC,Canada
 MPD,Air Plus Comet,RED COMET,Spain
@@ -3107,6 +3861,7 @@ MRF,Mauritanienne Air Fret,MAUR-FRET,Mauritania
 MRG,MANAG'AIR,MANAG'AIR,France
 MRH,RAF Marham,MARHAM,United Kingdom
 MRI,Servicios Aéreos Moritani,MORITANI,Mexico
+MRJ,Meraj Air,MERAJ AIRLINE,IR
 MRK,Markair,MARKAIR,United States
 MRL,Aeromorelos,AEROMORELOS,Mexico
 MRM,Aerocharter,MARITIME,Canada
@@ -3114,6 +3869,7 @@ MRN,Missions Gouvernemtales Francaises,MARIANNE,France
 MRO,Morrison Flying Service,MORRISON,United States
 MRP,Abas,ABAS,Czech Republic
 MRR,San Juan Airlines,MARINER,United States
+MRS,Marusya Airways,,Russia
 MRT,Air Mauritanie,MIKE ROMEO,Mauritania
 MRW,Mars RK,AVIAMARS,Ukraine
 MRX,Herman's Markair Express,SPEEDMARK,United States
@@ -3121,6 +3877,7 @@ MRY,Air Marine,AIR MARINE,France
 MRZ,Medical Air Rescue Services,MARS,Zimbabwe
 MSA,Mistral Air,AIRMERCI,Italy
 MSC,Air Cairo,,Egypt
+MSE,EgyptAir Express,,Egypt
 MSF,Minsheng International Jet,MEINSHENG,China
 MSG,Servico Aéreo Regional,SAR-REGIONAL,Mozambique
 MSH,US Marshals Service,MARSHALAIR,United States
@@ -3135,6 +3892,7 @@ MSP,Servicio De Vigilancia Aérea Del Ministerio De Seguridad Pública,SEGURIDAD
 MSQ,Meta Linhas Aéreas,META,Brazil
 MSR,Egyptair,EGYPTAIR,Egypt
 MSS,Morris Air Service,WASATCH,United States
+MSU,MGC Aviation,MALUTI SKY,LS
 MSV,Aero-Kamov,AERAFKAM,Russia
 MSW,Master Airways,MASTER AIRWAYS,Serbia
 MSX,Egyptair Cargo,EGYPTAIR CARGO,Egypt
@@ -3143,6 +3901,8 @@ MTA,GAK/Mitchell Aero,GAK AVIATION,United States
 MTB,Aerotaxis Metropolitanos,AEROMETROPOLIS,Mexico
 MTC,Mountain Air Company,MOUNTAIN LEONE,Sierra Leone
 MTD,MacKnight Airlines,,Australia
+MTE,Aeromet Linea Aerea,,Chile
+MTF,Interjet,,Italy
 MTG,Servicios Aéreos MTT,,Mexico
 MTH,Massachusetts Institute of Technology,RESEARCH,United States
 MTI,Monerrey Air Taxi,MONTERREY AIR,Mexico
@@ -3155,6 +3915,7 @@ MTP,Island Helicopters,METROCOPTER,United States
 MTR,Metroflight,METRO,United States
 MTS,Med Jets,,Mexico
 MTV,Mountain Valley Air Service,MOUNTAIN VALLEY,United States
+MTW,Mauritania Airways,,Mauritania
 MTX,Multi Taxi,MULTITAXI,Mexico
 MTY,Air Montegomery,MONTY,United Kingdom
 MTZ,Mali Airways,MALI AIRWAYS,Mali
@@ -3172,6 +3933,7 @@ MVK,Helicopter Training & Hire,MAVRIK,United Kingdom
 MVL,Mavial Magadan Airlines,Mavial,Russia
 MVM,Air Cargo America,PEGASUS,United States
 MVN,Marvin Limited,MARVIN,United Kingdom
+MVP,Corporate Air Travel LLC,ALLSTAR,United States
 MVR,Maverick Airways,MAV-AIR,United States
 MVY,VIM-Aviaservice,,Russia
 MWA,Midwest Airlines (Egypt),,Egypt
@@ -3188,7 +3950,10 @@ MXC,Compania Mexicargo,MEXICARGO,Mexico
 MXD,Malindo Airways,MALINDO EXPRESS,Malaysia
 MXE,Mocambique Expresso,MOZAMBIQUE EXPRESS,Mozambique
 MXF,Maximum Flight Advantages,MAXFLIGHT,United States
+MXI,MexicanaLink,,Mexico
+MXJ,Maxjet Airways,,United States
 MXL,Maxair,MAXAIR,Sweden
+MXM,Maximus Airlines,MAXLINES,Ukraine
 MXO,Aerotaxi Mexicano,MAXAERO,Mexico
 MXP,May Air Xpress,BEECHNUT,United States
 MXQ,Transportes Aéreos Mexiquenses,MEXIQUENSES,Mexico
@@ -3196,12 +3961,15 @@ MXS,Millon Express,MILLON EXPRESS,United States
 MXT,México Transportes Aéreos,TRANSMEX,Mexico
 MXU,Maximus Air Cargo,CARGO MAX,United Arab Emirates
 MXX,Merchant Express Aviation,MERCHANT,Nigeria
+MXY,Breeze Airways,MOXY,United States
 MYA,Myflug,MYFLUG,Iceland
 MYD,Maya Island Air,MYLAND,Belize
 MYI,Mayair,MAYAIR,Mexico
 MYO,Dominguez Toledo (Grupo Mayoral),MAYORAL,Spain
 MYP,Mann Yadanarpon Airlines,MANN ROYAL,Myanmar
 MYS,Aero Yaqui Mayo,AERO YAQUI,Mexico
+MYT,MyTravel Airways,,United Kingdom
+MYU,My Indo Airlines,INDO,Indonesia
 MYW,MyWay Airlines,MYSKY,Georgia
 MYX,Smartlynx Airlines Estonia,TALLINN CAT,Estonia
 MZA,Irtysh Air,IRTYSH AIRLINES,Kazakhstan
@@ -3209,6 +3977,10 @@ MZE,Zenith Aviation (Malta),,Malta
 MZK,AVC Airlines,,Japan
 MZL,Aerovías Montes Azules,MONTES AZULES,Mexico
 MZS,Mahfooz Aviation,MAHFOOZ,Gambia
+N12,12 North,,India
+N77,All Spain,,Spain
+N78,Regional Air Iceland,,Iceland
+N99,All Europe,,United Kingdom
 NAA,Norwegian Air Argentina,NORUEGA,Argentina
 NAB,Mina Airline Company,,Egypt
 NAC,Northern Air Cargo,YUKON,United States
@@ -3218,7 +3990,7 @@ NAF,Royal Netherlands Air Force,NETHERLANDS AIR FORCE,Netherlands
 NAH,Nahanni Air Services Ltd,NAHANNI,Canada
 NAI,North Adria Aviation,NORTH-ADRIA,Croatia
 NAJ,North American Jet Charter Group,JET GROUP,United States
-NAK,École Nationale de l'Aviation Civile,ENAC SCHOOL,France
+NAK,ENAC,ENAC SCHOOL,France
 NAL,Northway Aviation Ltd,NORTHWAY,Canada
 NAM,Nortland Air Manitoba,MANITOBA,Canada
 NAN,Norwegian Air Norway,NORSHIP,Norway
@@ -3240,11 +4012,12 @@ NBR,Haughey Air,NORBROOK,United Kingdom
 NBS,Nimbus Aviation,NIMBUS,United Kingdom
 NCA,Nippon Cargo Airlines,NIPPON CARGO,Japan
 NCB,North Caribou Flying Service Ltd,NORTH CARIBOU,Canada
-NCC,T3 Aviation, Inc.,STARFLEET,United States
+NCC,T3 Aviation Inc.,STARFLEET,Canada
 NCE,Northcoast Executive Airlines,TOP HAT,United States
 NCF,Norfolk County Flight College,COUNTY,United Kingdom
 NCG,Nederlandse Kustwacht,NETHERLANDS COASTGUARD,Netherlands
 NCH,Chanchangi Airlines,CHANCHANGI,Nigeria
+NCJ,North Central Aviation Inc,NORTH CENTRAL,United States
 NCL,ACA-Ancargo Air Sociedade de Transporte de Carga Lda,ANCARGO AIR,Angola
 NCM,Nas Air,AIR BANE,Angola
 NCN,National Airlines,,Chile
@@ -3254,7 +4027,10 @@ NCR,National Air Cargo dba National Airlines,NATIONAL CARGO,United States
 NCS,Simpson Air Ltd,COMMUTER-CANADA,Canada
 NCT,NokScoot,BIG BIRD,Thailand
 NDA,Northern Airways,NORTHERN DAKOTA,United States
+NDC,FlyNordic,,Sweden
 NDF,Namibian Defence Force,NAMIBIAN AIR FORCE,Namibia
+NDL,Chrono Aviation,NEEDLE,Canada
+NDN,Transportes Aereos Cielos Andinos,,Peru
 NDS,Nordstree (Australia),,Australia
 NDU,University of North Dakota,SIOUX,United States
 NEA,New England Airlines,NEW ENGLAND,United States
@@ -3266,6 +4042,7 @@ NEG,Línea Aérea de Fumig Aguas Negras,AGUAS NEGRAS,Chile
 NEJ,Netjets Business Aviation,NET BUSINESS,China
 NEL,Aero Servicios de Nuevo Laredo,AEROLAREDO,Mexico
 NEN,North-East Airlines,NORTHEAST SWAN,Nigeria
+NEP,MY Jet Xpress,WARISAN,MY
 NER,Air Newark,NEWAIR,United States
 NES,Nordeste Linhas Aéreas Regionais,NORDESTE,Brazil
 NET,Network Aviation Services,NETWORK,Nigeria
@@ -3274,31 +4051,40 @@ NEX,Northern Executive Aviation,NEATAX,United Kingdom
 NEZ,New England Air Express,ENGAIR,United States
 NFA,North Flying,NORTH FLYING,Denmark
 NFC,North Atlantic Cargo,NORTH ATLANTIC,Norway
+NFD,Nürnberger Flugdienst,,Germany
 NFF,Aircraft Support and Services,,Lebanon
 NFL,Northaire Freight Lines,GREAT LAKES,United States
 NFS,Afrique CArgo Service Senegal,,Senegal
 NFT,Nefteyugansk Aviation Division,NEFTEAVIA,Russia
 NGA,Nigeria Airways,NIGERIA,Nigeria
+NGB,Nordic Global Airlines,,Finland
 NGC,Angoservice,ANGOSERVICE,Angola
+NGE,Angel Airlines,,Thailand
 NGF,Air Charity Network,ANGEL FLIGHT,United States
 NGK,Oriental Air Bridge,ORIENTAL BRIDGE,Japan
+NGL,MaxAir,MAXAIR NIGERIA,NG
 NGO,Air-Angol,AIR ANGOL,Angola
+NGP,Air Nigeria,,Nigeria
 NGR,Nigerian Air Force,NIGERIAN AIRFORCE,Nigeria
 NGV,Angoavia,ANGOAVIA,Angola
 NGX,Nigerian Global,AIR GLOBAL,Nigeria
 NHC,Northern Helicopter,NORTHERN,Germany
+NHE,Nord Helikopter AS,NORD,NO
 NHG,NHT Linhas Aéreas,HELGA,Brazil
 NHK,Federal Aviation Administration,NIGHTHAWK,United States
 NHL,Northumbria Helicopters,NORTHUMBRIA,United Kingdom
 NHR,Nuevo Horizonte Internacional,NUEVO HORIZONTE,Mexico
 NHT,New Heights 291,NEWHEIGHTS,South Africa
 NHV,NHV Helicopters,,United Kingdom
+NHX,NHV - Noordzee Helikopters Vlaanderen,EVO,BE
 NHZ,Nada Air Service,NADA AIR,Chad
+NIA,Nile Air,,Egypt
 NIC,Northern Illinois Commuter,ILLINOIS COMMUTER,United States
 NID,Aeroni,AERONI,Mexico
 NIE,Aeroejecutiva Nieto,AERONIETO,Mexico
 NIG,Aero Contractors,AEROLINE,Nigeria
 NIH,NAM Air,NAM,Indonesia
+NIM,Air Nimbus - Operacoes Aereas S.A,NIMJET,Portugal
 NIN,Niger Airlines,NIGER AIRLINES,Niger
 NIR,Norsk Flytjeneste,NORSEMAN,Norway
 NIS,Nicaragüense de Aviación,NICA,Nicaragua
@@ -3306,7 +4092,10 @@ NIT,Midwest Aviation,NIGHTTRAIN,United States
 NJA,New Japan Aviation,SHIN NIHON,Japan
 NJC,Nashville Jet Charters,NASHVILLE JET,United States
 NJE,NetJets Europe,FRACTION,Portugal
+NJF,NasJet,,Soth Africa
+NJM,Northern Jet Management,NORTHERN JET,United States
 NJS,National Jet Systems,NATIONAL JET,Australia
+NJT,NetJets International,NETJET,United States
 NJU,NetJets UK,,United Kingdom
 NKF,Barents AirLink,NORDFLIGHT,Sweden
 NKL,Nakheel Aviation,NAKHEEL,United Arab Emirates
@@ -3319,14 +4108,18 @@ NLA,Neiltown Air,NEILTOWN AIR,Canada
 NLC,Nelair Charters,NELAIR,South Africa
 NLG,NEL Cargo,NELCARGO,Ivory Coast
 NLH,Norwegian Long Haul,NORSTAR,Norway
+NLI,Northern Air Charter,NORTH LINK,Canada
 NLK,Elbrus-Avia Air Enterprise,ELAVIA,Russia
 NLL,Northafrican Air Transport,NORTHAFRICAN AIR,Libya
 NLS,Nationale Luchtvaartschool,PANDER,Netherlands
 NLT,Newfoundland Labrador Air Transport,NALAIR,Canada
+NLU,Insel Air Aruba,INSEL ARUBA,Curaçao
 NLW,Nile Wings Aviation Services,NILE WINGS,Sudan
 NLY,Niki,FLYNIKI,Austria
+NMA,Nesma Airlines,,Egypt
 NMB,Air Namibia,NAMIBIA,Namibia
 NMD,Nomad Aviation,NOMAD AIR,Namibia
+NMG,Genghis Khan Airlines,TIANJIAO AIR,China
 NMI,Pacific Wings,TSUNAMI,United States
 NML,Gambia New Millennium Air,NEWMILL,Gambia
 NOA,Norontair,NORONTAIR,Canada
@@ -3343,7 +4136,9 @@ NOT,Línea Aérea Costa Norte,COSTA NORTE,Chile
 NOV,Nova Airline,NOVANILE,Sudan
 NOW,Royal Norwegian Air Force,NORWEGIAN,Norway
 NOY,Noy Aviation,NOY AVIATION,Israel
+NOZ,Norwegian Air Shuttle,NORSEMAN,Norway
 NPC,Western Air Couriers,NORPAC,United States
+NPL,Air Nepal International,,Nepal
 NPO,Novosibirsk Aviation Production Association,NOVSIB,Russia
 NPR,Air Napier,,New Zealand
 NPT,West Atlantic UK,NEPTUNE,United Kingdom
@@ -3355,6 +4150,7 @@ NRG,Ross Aviation,ENERGY,United States
 NRK,Naturelink Charter,NATURELINK,South Africa
 NRL,Nolinor Aviation,NOLINOR,Canada
 NRN,Royal Netherland Navy,NETHERLANDS NAVY,Netherlands
+NRO,Aero Rent JSC,,Russia
 NRP,Aeronord-Grup,AERONORD,Moldova
 NRR,Natureair,NATUREAIR,Costa Rica
 NRS,Atlantic Richfield Company,NORTH SLOPE,United States
@@ -3367,6 +4163,8 @@ NSA,Nile Safaris Aviation,NILE SAFARIS,Sudan
 NSC,Societe De Transport Aerien De Mauritanie,TRANS-SOCIETE,Mauritania
 NSE,SATENA,SATENA,Colombia
 NSF,Northamptonshire School of Flying,NORTON,United Kingdom
+NSH,Sterling Aviation,NORTH-SHORE,United States
+NSJ,Nanshan Jet,NANSHAN,China
 NSK,Air Intersalonika,INTERSALONIKA,Greece
 NSL,Neric,NERICAIR,United Kingdom
 NSM,Global Jet Corporation,THUNDERCLOUD,United States
@@ -3374,16 +4172,22 @@ NSO,Aerolíneas Sosa,SOSA,Honduras
 NSP,Novosibirsk Aircraft Repairing Plant,NARPAIR,Russia
 NSR,Nine Star Airways,AIR STAR,Thailand
 NSS,Northstar Aviation,NORTHSTAR,United States
+NST,Pakistan Aviators & Aviation Ltd.,NISHAT,PK
 NSW,Country Connection Airlines,,Australia
+NSZ,Norwegian Air Sweden,NORLIGHT,Sweden
 NTA,Northern Thunderbird Air,THUNDERBIRD,Canada
 NTB,Servicios Aéreos Del Norte,SERVINORTE,Mexico
 NTC,Gibson Aviation,NIGHT CHASE,United States
 NTD,Aero Norte,,Mexico
 NTE,Interaire,INTERMEX,Mexico
+NTF,OK Business Aircraft,NETFLIGHT,Czech Republic
 NTG,Servicios Integrales De Aviación,INTEGRALES,Mexico
 NTH,Hokkaido Air System,NORTH AIR,Japan
 NTJ,NextJet,NEXTJET,Sweden
 NTK,National Air Traffic Controllers Association,NATCA,United States
+NTL,Air Anatolia,,Turkey
+NTM,North American Airlines,,Canada
+NTN,National Airways Corporation,NATCHAIR,South Africa
 NTR,TNT International Aviation,NITRO,United Kingdom
 NTS,Cirrus Air,NITE STAR,United States
 NTT,Inter Tropic Airlines,INTER-TROPIC,Sierra Leone
@@ -3392,7 +4196,9 @@ NTW,Nationwide Airlines,NATIONWIDE,South Africa
 NTX,Northern Jet Management,NORTAX,United States
 NUB,Nomad Aviation,VALLETTA,Malta
 NUL,Aeroservicios De Nuevo Leon,SERVICIOS NUEVOLEON,Mexico
+NUM,Nomad Aviation AG,BULLY,Switzerland
 NUN,Nunasi-Central Airlines,NUNASI,Canada
+NUS,Northern Illinois Flight Center Inc,ENJET,United States
 NVA,Aeroclub de Albacete,,Spain
 NVC,Nav Canada,NAV CAN,Canada
 NVD,Avion Express,NORDVIND,Lithuania
@@ -3405,11 +4211,15 @@ NVM,Naviera Mexicana,NAVIERA,Mexico
 NVP,Navegacao Aérea De Portugal,,Portugal
 NVQ,Novo Air,NOVO AIR,Bangladesh
 NVR,Novair,NAVIGATOR,Sweden
+NVS,Nouvelle Air Affaires Gabon,NOUVELLE AFFAIRES,GA
 NVY,Royal Navy,NAVY,United Kingdom
 NWA,Delta Airlines,NORTHWEST,United States
+NWC,Aircompany North-West LLC,WEST WAY,Russia
 NWD,New World Jet Corporation,NEW WORLD,United States
 NWE,Northwest Aero Associates,,United States
+NWF,Northwest Flyers,SECOND CITY,United States
 NWG,Airwing,NORWING,Norway
+NWK,Network Aviation,NETLINK,AU
 NWL,North-Wright Airways,NORTHWRIGHT,Canada
 NWN,Northwinds Northern,NORTHWINDS,Canada
 NWO,RAF Northwood,,United Kingdom
@@ -3418,23 +4228,30 @@ NWS,Nordwind Airlines,NORDLAND,Russia
 NWT,Northwest Territorial Airways,TERRITORIAL,Canada
 NWW,North West Airlines,HALANT,Australia
 NWZ,Nationwide Airlines (Zambia),ZAMNAT,Zambia
+NX1,Nihon.jet connect,,Kyrgyzstan
 NXA,Air Next,BLUE-DOLPHIN,Japan
+NXB,NEXT Brasil,,Brazil
 NXF,Nextflight Aviation,NEXTFLIGHT,United States
 NXS,Nexus Aviation,NEXUS AVIATION,Nigeria
 NXT,National Express,NATIONAL FREIGHT,United States
+NXU,Nexus Flight Operations Services,NEXUS,SA
 NYA,Nanyah Aviation,NANYAH,Israel
 NYB,Belgian Navy,BELGIAN NAVY,Belgium
 NYH,New York Helicopter,NEW YORK,United States
 NYL,Mid Airlines,NILE,Sudan
 NYS,Nyasa Express,NYASA,Malawi
 NYT,Yeti Airlines,YETI AIRLINES,Nepal
+NYX,NyxAir,NYX AIR,Estonia
 NZA,Nayzak Air Transport,,Libya
 NZM,Mount Cook Airline,MOUNTCOOK,New Zealand
 OAA,Oxley Aviation,,Australia
+OAB,Orbit Airlines Azerbaijan,,Azerbaijan
 OAC,Oriental Airlines,ORIENTAL AIR,Nigeria
 OAD,Orscom Tourist Installations Company,ORSCOM,Egypt
 OAE,Omni Air International,OMNI-EXPRESS,United States
+OAI,Orbit International Airlines,,United States
 OAL,Olympic Air,OLYMPIC,Greece
+OAN,Orbit Atlantic Airways,,United States
 OAO,Arkhangelsk 2 Aviation Division,DVINA,Russia
 OAP,COAPA AIR,COAPA,Mexico
 OAR,ONE AIR,BOSS AIR,Spain
@@ -3443,11 +4260,15 @@ OAW,Helvetic Airways,HELVETIC,Switzerland
 OAX,Operational Aviation Services,,Australia
 OBA,Aerobanana,AEROBANANA,Mexico
 OBK,Amako Airlines,AMAKO AIR,Nigeria
+OBS,Orbest,,Portugal
+OBT,Orbit Airlines,,United States
 OCA,Aserca Airlines,AROSCA,Venezuela
 OCE,Heliocean,HELIOCEAN,France
+OCM,O'Connor Airlines,,Australia
 OCN,O Air,O-BIRD,France
 OCO,Ostend Air College,AIR COLLEGE,Belgium
 OCS,Ocean Sky (UK),OCEANSKY,United Kingdom
+ODI,Jonsson,,ODINN
 ODM,Pan African Airways,,Kenya
 ODS,Odessa Airlines,ODESSA AIR,Ukraine
 ODY,Odyssey International,ODYSSEY,Canada
@@ -3460,6 +4281,8 @@ OFF,Challenge International Airlines,CHALLENGE AIR,United States
 OGI,Aerogisa,AEROGISA,Mexico
 OGJ,Bakoji Airlines Services,BAKO AIR,Nigeria
 OGN,Origin Pacific Airways,ORIGIN,New Zealand
+OHC,Jet Select,OHIO CHARTER,United States
+OHK,Oasis Hong Kong Airlines,,Hong Kong
 OHY,Onur Air,ONUR AIR,Turkey
 OIC,Iwamoto Crane Co Ltd,,Japan
 OIX,Orion-x,ORIONIX,Russia
@@ -3476,33 +4299,43 @@ OLC,Solar Cargo,SOLARCARGO,Venezuela
 OLE,Operadora de Lineas Ejecutivas,OPERADORA,Mexico
 OLO,Soloflight,SOLO,United Kingdom
 OLR,Colaéreos,COLAEREOS,Ecuador
+OLS,Sol Lineas Aereas,,Argentina
 OLT,OLT Express Germany,OLTRA,Germany
 OLV,Aerolíneas Olve,OLVE,Mexico
 OLX,Olimex Aerotaxi,OLIMEX,Czech Republic
 OLY,Olympic Aviation,OLAVIA,Greece
 OMA,Oman Air,OMAN AIR,Oman
+OMD,Nomadic Aviation,NOMADIC,United States
+OME,Homer Air,,Germany
 OMF,Omniflys,OMNIFLYS,Mexico
 OMG,Aeromega,OMEGA,United Kingdom
 OML,Organizacoes Mambra,MAMBRA,Angola
 OMN,Servicios Aereos Ominia,SERVIOMNIA,Mexico
+OMP,Nomadic Aviation,NOMADIC,United States
 OMR,Minair,ORMINE,Central African Republic
 OMS,SalamAir,MAZOON,Oman
 ONE,Avianca Brazil,OCEAN AIR,Brazil
 ONG,Sonnig SA,SONNIG,Switzerland
 ONM,Presidencia de La Republica de Guinea Ecuatorial,,Equatorial Guinea
+ONO,Aeronor SA de CV,NORAERO,Mexico
 ONR,Air One Nine,EDER,Libya
 ONS,One Airlines,AIR DREAMS,Chile
 ONT,Air Ontario,ONTARIO,Canada
+OOM,Zoom Airlines,,Canada
 OOT,Out Of The Blue Air Safaris,OOTBAS,South Africa
 OPA,Opal Air,,Australia
 OPC,Krystel Air Charter,OPTIC,United Kingdom
+OPM,Fireblade Aviation,,South Africa
+OPS,Jet-Ops,,United Arab Emirates
 OPT,Flight Options,OPTIONS,United States
 OPV,Operadora de Veulos Ejectutivos,OPERADORA DE VUELOS,Mexico
 ORA,Long Island Airlines,LONG ISLAND,United States
 ORB,Orenburg Airlines,ORENBURG,Russia
+ORC,Orchid Airlines,,Australia
 ORD,Orange Air Services,ORANGE SERVICES,Sierra Leone
 ORE,Orange Aviation,ORANGE AVIATION,Israel
 ORF,Oman Royal Flight,OMAN,Oman
+ORG,Orenburzhie,,Russia
 ORJ,Orange Air Sierra Leone,ORANGE SIERRA,Sierra Leone
 ORK,Orca Air,ORCA TAXI,Egypt
 ORL,On Air Limited,ON AIR,Canada
@@ -3523,15 +4356,19 @@ OSO,Aviapartner Limited Company,,Russia
 OSS,Servicios Aéreos Noticiosos,NOTICIOSOS,Mexico
 OST,Airline Alania,ALANIA,Russia
 OSU,Ohio State University,SCARLET,United States
+OSW,JetAfrica Swaziland,,Swaziland
 OSY,Open Skies Consultative Commission,OPEN SKIES,United States
 OTA,Business Aviators,OUTLAW,United States
+OTC,Air Travel,AIR TRAVEL,China
 OTG,One Two Go Airlines,THAI EXPRESS,Thailand
+OTJ,Fly Romania,,Romania
 OTL,South Airlines,SOUTHLINE,Ukraine
 OTM,Onetime Airlines Zambia,ZEDTIME,Zambia
 OTN,LASTP,LASTP,São Tomé and Príncipe
 OTP,Operadora de Transportes Aéreos,OPERADORA AEREO,Mexico
 OTR,Orient Airlines,ORIENTROC,Sudan
 OUF,Beijing Eofa International Jet,,China
+OUL,Air Atonabee,,Canada
 OVA,Aero Nova,AERONOVA,Spain
 OVC,Aerovic,,Ecuador
 OVE,Aeromover,AEROMOVER,Mexico
@@ -3540,11 +4377,13 @@ OVV,Orient Air,ORIENTSYR,Syrian Arab Republic
 OWE,Owenair,OWENAIR,South Africa
 OWL,Miami Valley Aviation,NIGHT OWL,United States
 OWN,Aero Owen,AERO OWEN,Mexico
+OWT,TwoFlex,BRASIL CARGO,BR
 OXE,Oxaero,OXOE,United Kingdom
 OXF,Oxford Aviation Academy,,United Kingdom
 OXO,Million Air,MILL AIR,United States
 OYE,Koda International,KODA AIR,Nigeria
 OZJ,Ozjet Airlines,AUSJET,Australia
+OZR,Ozark Air Lines,,United States
 OZU,Hozu-Avia,HOZAVIA,Kazakhstan
 OZW,Virgin Australia Regional Airlines,VELOCITY,Australia
 PAA,Pan American World Airways,CLIPPER,United States
@@ -3552,6 +4391,7 @@ PAB,Pacific Air Boats,AIR BOATS,Canada
 PAC,Polar Air Cargo,POLAR,United States
 PAD,Professional Express Courier Service,AIR PROFESSIONAL,United States
 PAE,Paisajes Españoles,PAISAJES,Spain
+PAF,Pathfinder Aviation LLC,PATHFINDER,United States
 PAG,Perimeter Aviation,PERIMETER,Canada
 PAH,Panorama Air Tour,LANI,United States
 PAI,Paradise Airways,SEA RAY,United States
@@ -3571,6 +4411,8 @@ PAX,Pan Air,PANNEX,United States
 PAZ,Point Afrique Niger,POINTAIR NIGER,Niger
 PBA,PB Air,PEEBEE AIR,Thailand
 PBB,Polizeihubschrauberstaffel Brandenburg,ADEBAR,Germany
+PBC,Aerotaxis Paba SA de CV,,Mexico
+PBD,Pobeda,,Russia
 PBN,Pacific Blue,BLUEBIRD,New Zealand
 PBR,Fast Air,POLAR BEAR,Canada
 PBT,Air Parabet,PARABET,Bangladesh
@@ -3580,8 +4422,10 @@ PBY,Pearl Air Services,PEARL SERVICES,Uganda
 PCA,Penya De L'Aire,PENA DEL AIRE,Spain
 PCC,Perforadora Central,PERFORADORA CENTRAL,Mexico
 PCE,Pace Airlines,PACE,United States
+PCF,Pacific Air Express,,United States
 PCG,Aeropostal Cargo de Mexico,POSTAL CARGO,Mexico
 PCH,Pilatus Flugzeugwerke,PILATUS WINGS,Switzerland
+PCI,Protea Coin Group,PROTEA COIN,South Africa
 PCJ,Pacific Jet,PACIFIC JET,United States
 PCK,Air Pack Express,AIRPACK EXPRESS,Spain
 PCL,Pinnacle Air Group,PINNACLE GROUP,United States
@@ -3591,6 +4435,7 @@ PCO,Pacific Coastal Airlines,PASCO,Canada
 PCP,Aerolínea Principal Chile,PRINCIPAL,Chile
 PCR,PAC Air,PACAIR,United States
 PCS,Air Palace,AIR PALACE,Mexico
+PCT,Peace Air Togo,PEACEFUL,Togo
 PCV,Pacific Aviation (Australia),PACAV,Australia
 PCW,Trans-Pacific Orient Airways,PACIFIC ORIENT,Philippines
 PCX,Pacific Aviation (United States),,United States
@@ -3603,6 +4448,7 @@ PDI,Paradise Island Airways,PARADISE ISLAND,United States
 PDQ,PDQ Air Charter,DISPATCH,United States
 PDR,COMAV,SPEEDSTER,Namibia
 PDT,Piedmont Airlines,PIEDMONT,United States
+PDU,Purdue University,PURDUE,United States
 PDV,Elicar,ELICAR,Italy
 PDY,Pen-Avia,PENDLEY,United Kingdom
 PEA,Pan Europeenne Air Service,,France
@@ -3620,7 +4466,9 @@ PEV,Peoples Vienna Line,PEOPLES,Austria
 PEX,Pelican Express,PELICAN EXPRESS,United States
 PFA,Pacific Flight Services,PACIFIC SING,Singapore
 PFI,Aerolíneas Chihuahua,PACIFICO CHIHUAHUA,Mexico
+PFL,Pacific Flier,,Palau
 PFN,Pan African Air Services,PANAFRICAN,Sierra Leone
+PFP,Mexican Federal Police,POLICIA FEDERAL,Mexico
 PFR,Pacificair Airlines,PACIFIC WEST,United States
 PFS,Prairie Flying Service,PRAIRIE,United States
 PFT,Air Cargo Express International,PROFREIGHT,United States
@@ -3631,6 +4479,7 @@ PGF,Paragon Global Flight Support,,United Kingdom
 PGH,Pulkovo Aircraft Services,,Russia
 PGI,Panagra Airways,PANAGRA,United States
 PGL,Premiair Aviation Services,PREMIERE,United Kingdom
+PGN,Tailwind Air,PERGRINE,United States
 PGP,Perm Airlines,PERM AIR,Russia
 PGS,Tauranga Aer Club,,New Zealand
 PGT,Pegasus Airlines,SUNTURK,Turkey
@@ -3673,9 +4522,13 @@ PJA,Private Jet Management,PRIVATE FLIGHT,United States
 PJC,Pittsburgh Jet Center,,United States
 PJE,Private Jet Expeditions,PEE JAY,United States
 PJP,Princely Jets,PRINCELY JETS,Pakistan
+PJS,Jet Aviation,,Switzerland
+PJT,Partner Jet Inc,PARTNERJET,Canada
+PJZ,Premium Jet AG,PRIMEJET,Switzerland
 PKA,AST Pakistan Airways,PAKISTAN AIRWAY,Pakistan
 PKP,Mountain Air Express,PIKES PEAK,United States
 PKR,Pakker Avio,PAKKER AVIO,Estonia
+PKV,Псковавиа,,Russia
 PKW,Pak West Airlines,PLATINUM WEST,United States
 PKZ,Prime Aviation,PRAVI,Kazakhstan
 PLA,Polynesian Air-Ways,POLYAIR,United States
@@ -3683,6 +4536,7 @@ PLB,Polynesian Blue,POLYBLUE,New Zealand
 PLC,Police Aviation Services,SPECIAL,United Kingdom
 PLF,Polish Air Force,POLISH AIRFORCE,Poland
 PLG,MBK-S,PILGRIM,Russia
+PLI,Aeroper,,Peru
 PLL,Air Pal,AIRPAL,Spain
 PLM,Air Pullmantur,PULLMANTUR,Spain
 PLN,Planar,PLANAR,Angola
@@ -3697,6 +4551,7 @@ PMA,Pan Malaysian Air Transport,PAN MALAYSIA,Malaysia
 PMC,Primas Courier,PRIMAC,United States
 PME,Premiair Fliyng Club,ADUR,United Kingdom
 PMI,Primero Transportes Aereos,AEROEPRIM,Mexico
+PMK,Palair Macedonia,,Macedonia
 PMM,Paradigm Air Operators,PARADIGM,United States
 PMO,Polar Airlines de Mexico,POLAR MEXICO,Mexico
 PMR,Servicios Aéreos Premier,SERVICIOS PREMIER,Mexico
@@ -3711,11 +4566,13 @@ PNA,Palau National Airlines,SEBUS,Palau
 PNC,Prince Aviation,PRINCE,Serbia
 PND,Pond Air Express,POND AIR,United States
 PNE,Peninter Aérea,PENINTER,Mexico
+PNF,Panafrican Airways,,Ivory Coast
 PNG,Puerto Rico National Guard,,United States
 PNH,Panh,KUBAN LIK,Russia
 PNK,Air Pink,AIRPINK,Serbia
 PNL,Aero Personal,AEROPERSONAL,Mexico
 PNM,Panorama,PANORAMA,Spain
+PNO,Panorama Aviation,PANO,Canada
 PNP,Pineapple Air,PINEAPPLE AIR,Bahamas
 PNR,PAN Air,SKYJET,Spain
 PNS,Survey Udara (Penas),PENAS,Indonesia
@@ -3741,12 +4598,15 @@ PPA,Propheter Aviation,AIR PROP,United States
 PPC,Palau Asia Pacific Airlines,PALAU ASIAPAC,Palau
 PPG,Phoenix Air Transport,PAPAGO,United States
 PPH,Polizeihubschrauberstaffel Niedersachsen,POLICE PHOENIX,Germany
+PPJ,Premier Jets,PREMIER JETS,United States
 PPK,Ramp 66,PELICAN,United States
+PPL,Air Pegasus,,India
 PPM,Pacific Pearl Airways,PACIFIC PEARL,Philippines
 PPQ,Personas Y Pasquetes Por Air,PERSONSPAQ,Mexico
 PPS,Butte Aviation,PIPESTONE,United States
 PPW,Royal Phnom Penh Airways,PHNOM-PENH AIR,Cambodia
 PQA,Pacific Coast Airlines,SAGE BRUSH,United States
+PQW,PanAm World Airways,,United States
 PRA,Pars Aviation Service,PARSAVIA,Iran
 PRC,Pacific Air Charter,PACIFIC CHARTER,United States
 PRD,Presidential Aviation,PRESIDENTIAL,United States
@@ -3766,13 +4626,17 @@ PRV,Provincial Express,PROVINCIAL,Canada
 PRW,Primera Air Nordic,JETBIRD,Latvia
 PRX,VIP Avia,PAREX,Latvia
 PRY,Priority Air Charter,PRIORITY AIR,United States
+PRZ,Air Paradise International,,Indonesia
 PSA,Pacific Island Aviation,PACIFIC ISLE,United States
+PSB,Syrian Pearl Airlines,,Syria
 PSC,Pascan Aviation,PASCAN,Canada
 PSD,President Airlines,,Cambodia
 PSE,Aeroservicio Sipse,SIPSE,Mexico
 PSF,Plymouth School of Flying,LIZARD,United Kingdom
 PSG,Aviones Para Servirle,SERVIAVIONES,Mexico
 PSH,Red Aviation,PASSION,United Kingdom
+PSI,Pont International Airline Services,,Suriname
+PSK,Prescott,SUPPORT,United States
 PSL,Aeroservicios Corporativos De San Luis,CORSAN,Mexico
 PSN,Potosina Del Aire,POTOSINA,Mexico
 PSO,Aerotaxis Pegaso,AEROPEGASO,Mexico
@@ -3782,6 +4646,7 @@ PSS,TSSKB-Progress,PROGRESS,Russia
 PST,Parsa,TURISMO REGIONAL,Panama
 PSV,Servicios Aéreos Profesionales,PROSERVICIOS,Dominican Republic
 PSW,Pskovavia,PSKOVAVIA,Russia
+PSX,Pacific Southwest Airlines,,United States
 PSZ,Pro Air Service,POP-AIR,United States
 PTA,Ptarmigan Airways,PTARMIGAN,Canada
 PTB,Passaredo Transportes Aéreos,PASSAREDO,Brazil
@@ -3805,6 +4670,7 @@ PTY,Petty Transport,PETTY,United States
 PUA,PLUNA,PLUNA,Uruguay
 PUE,Aeropuelche,PUELCHE,Chile
 PUR,Spurwing Airlines,SPURWING,South Africa
+PUT,Aeroput,,Serbia
 PUV,Publivoo,PUBLIVOO,Portugal
 PVA,Aerotransportes Privados,TRANSPRIVADO,Mexico
 PVD,PADAVIATION,,Italy
@@ -3814,7 +4680,9 @@ PVK,Association of Private Pilots of Kazakhstan,BORIS,Kazakhstan
 PVL,Professione VOlare,VOLARE,Italy
 PVN,Peruvian Airlines,,Peru
 PVO,Bearing Supplies Limited,PROVOST,United Kingdom
+PVS,Privatair Saudi Arabia,PASA,SA
 PVU,Peau Vavaʻu,PEAU,Tonga
+PVV,Continental Airways,,Russia
 PVV[23][24],Fly Pro,Sunday,Moldova
 PWA,Priester Aviation,PRIESTER,United States
 PWC,Pratt and Whitney Canada,PRATT,Canada
@@ -3822,10 +4690,13 @@ PWD,Pawa Dominicana,Pawa Dominicana,Dominican Republic
 PWF,Private Wings Flugcharter,PRIVATE WINGS,Germany
 PWL,Powell Air,POWELL AIR,Canada
 PXA,Pecotox Air,PECOTOX,Moldova
+PXG,Aitheras Aviation Group LLC,PHOENIX GLOBAL,United States
 PXP,Pacific Air Transport,PAK EXPRESS,United States
 PXR,Pixair Survey,PIXAIR,France
 PXT,Pacific Coast Jet,PACK COAST,United States
 PXX,Aroostook Aviation,PINE STATE,United States
+PYA,Pouya Air,,Iran
+PYB,All America BOPY,,Paraguay
 PYC,Aeropycsa,AEROPYCSA,Mexico
 PYN,Haverfordwest Air Charter Services,POYSTON,United Kingdom
 PYR,Pyramid Air Lines,PYAIR,Egypt
@@ -3840,11 +4711,18 @@ QAI,Conquest Air,CHICKPEA,United States
 QAJ,Quick Air Jet Charter,DAGOBERT,Germany
 QAQ,Qurinea Air Service,QURINEA AIR,Libya
 QAS,Quisqueya Airlines,QUISQUEYA,Haiti
+QAT,Aero Taxi,,Canada
+QAX,QatXpress,,Qatar
+QAZ,Qazaq Air,SAMRUK,Kazakhstan
 QCC,Qwest Commuter Corporation,QWEST AIR,United States
 QCL,Air Class Líneas Aéreas,ACLA,Uruguay
+QDA,Qingdao Airlines,SKY LEGEND,China
 QEA,Aviation Consultancy Office,,Australia
+QER,SOCHI AIR CHATER,,Russia
 QFA,Qantas,QANTAS,Australia
+QFZ,Fars Air Qeshm,,Iran
 QGA,Windrose Air,QUADRIGA,Germany
+QHD,Meregrass Inc,QUAHADI,United States
 QID,USAF 100th Air Refueling Wing,QUID,United States
 QJE,QantasLink,QJET,Australia
 QKC,Aero Taxi Aviation,QUAKER CITY,United States
@@ -3852,8 +4730,12 @@ QLA,Aviation Quebec Labrador,QUEBEC LABRADOR,Canada
 QLK,QantasLink,QLINK,Australia
 QNA,Queen Air,QUEEN AIR,Dominican Republic
 QNK,Kabo Air,KABO,Nigeria
+QNR,Queen Air s.r.o,QUEEN AIR,Czech Republic
 QNT,Qanot Sharq,QANAT SHARQ,Uzbekistan
+QNZ,JetConnect,,New Zealand
 QQE,Qatar Executive,,Qatar
+QQQ,ENTERair,,Poland
+QRT,4D Air,,Thailand
 QSC,African Safari Airways,ZEBRA,Kenya
 QSM,Qeshm Air,QESHM AIR,Iran
 QSR,SR Jet,SPARKLE ROLL,China
@@ -3865,7 +4747,9 @@ QVR,Kvadro Aero,PEGASO,Kyrgyzstan
 QWA,Qwestair,,Australia
 QWL,Qwila Air,Q-CHARTER,South Africa
 QXE,Horizon Air,HORIZON AIR,United States
+R1R,All America CL,,Chile
 RAA,Rynes Aviation,RYNES AVIATION,United States
+RAB,Rainbow Air (RAI),,United States
 RAC,Icar Air,TUZLA AIR,Bosnia and Herzegovina
 RAD,Alada,AIR ALADA,Angola
 RAE,Régional Compagnie Aérienne Européenne,REGIONAL EUROPE,France
@@ -3881,10 +4765,13 @@ RAN,Renan,RENAN,Moldova
 RAP,Air Center Helicopters,RAPTOR,United States
 RAQ,Rath Aviation,RATH AVIATION,Austria
 RAR,Air Rarotonga,AIR RAROTONGA,Cook Islands
+RAS,Jim Ratliff Air Service,,United States
 RAT,Chief Rat Flight Services,RIVERRAT,South Africa
 RAU,Uganda Royal Airways,UGANDA ROYAL,Uganda
 RAV,Reed Aviation,REED AVIATION,United Kingdom
+RAW,Royal Airways,,United States
 RAX,Royal Air Freight,AIR ROYAL,United States
+RAY,Rainbow Air Canada,,Canada
 RAZ,Rijnmond Air Services,RIJNMOND,Netherlands
 RBA,Royal Brunei Airlines,BRUNEI,Brunei
 RBB,Rabbit-Air,RABBIT,Switzerland
@@ -3900,6 +4787,7 @@ RBT,Robinton Aero,ROBIN,Dominican Republic
 RBU,Airbus France,AIRBUS FRANCE,France
 RBV,Air Roberval,AIR ROBERVAL,Canada
 RBW,Shandong Airlines Rainbow Jet,CAI HONG,China
+RBX,Arubaexel,,Aruba
 RBY,Vision Airlines,RUBY,United States
 RCA,Richland Aviation,RICHLAND,United States
 RCB,Real Aero Club De Baleares,BALEARES,Spain
@@ -3919,10 +4807,14 @@ RCT,Skyview Airways,GREENSKY,THAILAND
 RCU,Atlantic S.L.,AIR COURIER,Spain
 RCX,Air Service Center,SERVICE CENTER,Italy
 RCY,Package Express,RACE CITY,United States
+RDA,Rada Airlines,RADA,Belarus
+RDD,Adygeya Airlines,,Russia
 RDE,II Lione Alato Arl,FLIGHT RED,United Kingdom
+RDF,Eurocopter Deutschland GmbH,RED FOX,Germany
 RDK,Irish Air Transport,IRISH TRANS,Ireland
 RDL,Roadair Lines,ROADAIR,Canada
 RDM,Air Ada,AIR ADA,Mauritania
+RDN,Dinar,,Argentina
 RDP,Eurojet Romania,JET-ARROW,Romania
 RDR,Goodridge (UK) Limited,RED STAR,United Kingdom
 RDS,Rhoades Aviation,RHOADES EXPRESS,United States
@@ -3935,12 +4827,14 @@ REC,Trans Reco,TRANS-RECO,Mauritania
 RED,International Committee of the Red Cross,RED CROSS,Switzerland
 REF,Reef Air,REEF AIR,New Zealand
 REG,Regional Air Services,REGIONAL SERVICES,Tanzania
+REH,Reach Air Medical Services,REACHMED,United States
 REI,Ray Aviation,RAY AVIATION,Israel
 REJ,SA Airlink Regional,REGIONAL LINK,South Africa
 REK,Reem Air,REEM AIR,Kyrgyzstan
 REL,Reliance Aviation,RELIANCE AIR,United States
 REN,Aero-Rent,AERORENT,Mexico
 REO,Rio Airways,RIO,United States
+REP,Regional Paraguaya,,Paraguay
 RER,Servicio Aéreo Regional Regair,REGAIR,Ecuador
 RES,Australian Maritime Safety Authority,RESCUE,Australia
 REU,Air Austral,REUNION,France
@@ -3954,13 +4848,16 @@ RFC,Aero Africa,AERO AFRICA,Swaziland
 RFD,Aerotransportes Rafilher,RAFHILER,Mexico
 RFF,Russian Federation Air Force,RUSSIAN AIRFORCE,Russia
 RFI,National Air Traffic Services,SHERLOCK,United Kingdom
+RFJ,Royal Falcon,,Jordan
 RFL,Interfly,INFLY,Italy
 RFR,Royal Air Force,RAFAIR,United Kingdom
 RFS,Rossair,,Australia
 RFT,Scoala Superioara De Aviatie Civila,ROMANIAN ACADEMY,Romania
+RFX,J P Hunt Air Carriers,,United States
 RGA,Royal Ghanaian Airlines,ROYAL GHANA,Ghana
 RGC,Servicios Aéreos Regiomontanos,REGIOMONTANO,Mexico
 RGE,Regent Airways,REGENT,Bangladesh
+RGG,TransRussiaAirlines,,Russia
 RGL,Regional Air Lines,MAROC REGIONAL,Morocco
 RGM,Rangemile Limited,RANGEMILE,United Kingdom
 RGN,Cygnus Air,CYGNUS AIR,Spain
@@ -3971,6 +4868,7 @@ RGS,Renown Aviation,RENOWN,United States
 RGT,Airbourne School of Flying,AIRGOAT,United Kingdom
 RGV,RG Aviation,,Venezuela
 RGY,Regency Airlines,REGENCY,United States
+RHA,Robin Hood Aviation,,Austria
 RHC,Redhill Aviation,REDAIR,United Kingdom
 RHD,Bond Air Services,RED HEAD,United Kingdom
 RHH,Red Star Aviation,,Turkey
@@ -3979,6 +4877,7 @@ RIA,Rich International Airways,RICHAIR,United States
 RIC,Richardson's Airway,RICHARDSON,United States
 RID,Ridder Avia,AKRID,Kazakhstan
 RIF,Aviation Ministry of the Interior of the Russian Federation,INTERMIN AVIA,Russian Federation
+RIH,Rahila Air,RAHILA,LY
 RIL,Regional Air,,Mauritania
 RIM,Rimrock Airlines,RIMROCK,United States
 RIO,Rio Linhas Aéreas,RIO,Brazil
@@ -3989,20 +4888,26 @@ RIV,APG Airlines,RIVERA,France
 RIX,Rectrix Aviation,RECTRIX,United States
 RJA,Royal Jordanian,JORDANIAN,Jordan
 RJC,Richmor Aviation,COLUMBIA JET,United States
+RJD,Rotana Jet,,United Arab Emirates
 RJM,Millen Corporation,MILLEN,United Kingdom
+RJR,Air CM Global,MELITA,Malta
 RJS,Aeroservicios Jet,ASERJET,Mexico
 RJT,RA Jet Aeroservicios,RA JET,Mexico
 RJZ,Royal Jordanian Air Force,JORDAN AIR FORCE,Jordan
 RKA,Air Afrique,AIRAFRIC,Ivory Coast
 RKC,DAS Airlines,DAS CONGO,Democratic Republic of the Congo
 RKH,Royal Khmer Airlines,KHMER AIR,Cambodia
+RKK,Stephens Investment Holdings LLC,ROCKTOWN,United States
 RKM,RAK Airways,RAKAIR,United Arab Emirates
+RKS,Phenix Jet,ROCKSTAR,United States
 RKT,Rotormotion,ROCKET,United Kingdom
 RKW,Rockwell Collins Avionics,ROCKWELL,United States
 RLA,Airlinair,AIRLINAIR,France
 RLE,Rico Linhas Aéreas,RICO,Brazil
 RLH,Ruili Airlines,SENDI,China
+RLI,Reliant Air Charter,RELIANT,United States
 RLJ,Empyreal Jet Service,,United States
+RLK,Air Nelson,,New Zealand
 RLL,Air Leone,AEROLEONE,Sierra Leone
 RLM,Royal American Airways,ROYAL AMERICAN,United States
 RLN,Aero Lanka,AERO LANKA,Sri Lanka
@@ -4011,28 +4916,39 @@ RLS,S-Air,S-AIRLINES,Russia
 RLT,Reliant Airlines,RELIANT,United States
 RLU,Rusline,RUSLINE AIR,Russia
 RLV,Real Aviation,REAL,Ghana
+RLX,Go2Sky,,Slovakia
+RLY,Air Loyaute,LOYAUTE,NC
 RLZ,Air Alize,ALIZE,France
 RMA,Rocky Mountain Airways,ROCKY MOUNTAIN,United States
 RMD,Air Amder,AIR AMDER,Mauritania
+RME,Armenian Airlines,,Armenia
 RMF,Royal Malaysian Air Force,ANGKASA,Malaysia
 RMG,Rumugu Air & Space Nigeria,RUMUGU AIR,Nigeria
 RMI,Point Airlines,POINT AIRLINE,Nigeria
+RMK,Simrik Airlines,,Nepal
 RML,Air Mediterranean,HELLASMED,Greece
 RMO,Arm-Aero,ARM-AERO,Armenia
 RMP,Servicios De Rampa Y Mostrador,SERAMSA,Mexico
 RMS,Tas Aviation,TASS AIR,United States
 RMT,Ram Aircraft Corporation,RAM FLIGHT,United States
-RMU,C.S.P., Societe,AIR-MAUR,Mauritania
+RMU,C.S.P. Societe,AIR-MAUR,Mauritania
 RMV,Romavia,AEROMAVIA,Romania
 RMX,Air Max,AEROMAX,Bulgaria
+RMY,Raya Airways,RAYA EXPRESS,MY
 RNA,Nepal Airlines,ROYAL NEPAL,Nepal
 RNB,Rosneft-Baltika,ROSBALT,Russia
 RND,Rutland Aviation,RUTLAND,United Kingdom
 RNE,Air Salone,AIR SALONE,Sierra Leone
 RNG,Orange Aircraft Leasing,ORANGE,Netherlands
+RNI,Rennia Aviation,RENNIA,United States
 RNM,Aeronem Air Cargo,AEROMNEM,Ecuador
 RNR,Air Cargo Masters,RUNNER,United States
 RNS,Ronso,RONSO,Mexico
+RNV,Armavia,,Armenia
+RNX,1Time Airline,,South Africa
+RNY,Rainbow Air US,,United States
+ROA,Reno Air,,United States
+ROB,ROYAL BRITAIN,,United Kingdom
 ROC,Rocky Mountain Airlines,,Canada
 ROD,Aerodan,AERODAN,Mexico
 ROE,Aeroeste,ESTE-BOLIVIA,Bolivia
@@ -4041,7 +4957,9 @@ ROG,FundaciÃ³ Rego,REGO,Spain
 ROH,Aberdair Aviation Ghana,,Ghana
 ROI,Avior Airlines,AVIOR,Venezuela
 ROJ,Royal Jet,ROYALJET,United Arab Emirates
+ROK,National Airlines,,United States
 ROL,Aeroel Airways,AEROEL,Israel
+ROM,Aeromar,,Dominican Republic
 RON,Our Airline,OUR AIRLINE,Nauru
 ROO,Aero Roa,AERO ROA,Mexico
 ROP,Royal Oman Police,,Oman
@@ -4058,41 +4976,55 @@ RPB,AeroRepública,AEROREPUBLICA,Colombia
 RPC,Aerolíneas Del Pacífico,AEROPACSA,Ecuador
 RPH,Republic Express Airlines,PUBLIC EXPRESS,Indonesia
 RPK,Royal Airlines,ROYAL PAKISTAN,Pakistan
+RPO,Rainbow Air Polynesia,,United States
 RPS,Global Air Charter,RESPONSE,United States
 RPX,BAC Express Airlines,RAPEX,United Kingdom
+RQT,Airquest Aviation,AIR QUEST,United States
+RQX,Air Engiadina-BRN,,Switzerland
 RRA,Royal Rwanda Airlines,ROYAL RWANDA,Rwanda
 RRB,Aero Club de Castellon,,Spain
 RRC,Aero Roca,AEROROCA,Mexico
 RRE,Aerotransportes Internacionales De Torreon,AERO TORREON,Mexico
 RRF,Royal Air Force,KITTY,United Kingdom
 RRH,Redstar Aviation,STAR CRESCENT,Turkey
+RRJ,AirRussia,,Russia
 RRL,Rolls-Royce Limited,MERLIN,United Kingdom
+RRM,Acvila Air-Romanian Carrier,,Romania
 RRO,Aerocredo,,Russia
 RRR,Royal Air Force,ASCOT,United Kingdom
 RRS,Boscombe Down DERA (Formation),BLACKBOX,United Kingdom
 RRT,Transportes Aéreos Sierra,SIERRA ALTA,Mexico
+RRU,Cirrus,,Chile
 RRV,Mombasa Air Safari,SKYROVER,Kenya
 RRY,Tbilisi Aviation University,AIRFERRY,Georgia
 RRZ,Rollright Aviation,ROLLRIGHT,United Kingdom
+RS1,Royal Southern Airlines.,,Colombia
 RSA,Elisra Airlines,ESRA,Sudan
 RSB,Rubystar,RUBYSTAR,Belarus
 RSC,Aerolíneas Ejecutivas Tarascas,TARASCAS,Mexico
+RSD,Russia State Transport,,Russia
 RSE,SNAS Aviation,RED SEA,Saudi Arabia
 RSF,Royal Saudi Air Force,ARSAF,Saudi Arabia
 RSH,Air Sahara,SAHARA,India
 RSI,Air Sunshine,AIR SUNSHINE,United States
+RSJ,RusJet,,Russia
 RSK,DSWA,REDSKIN,United States
 RSL,Panama Aircraft Rental and Sales,PANAMA RENTAL,Panama
 RSM,Air Somalia,AIR SOMALIA,Somali Republic
 RSN,Royal Swazi National Airways,SWAZI NATIONAL,Swaziland
+RSO,Aero Asia International,,Pakistan
+RSP,Jet Suite,,United States
 RSQ,International SOS WIndhoek,SKYMEDIC,Namibia
 RSR,Aero-Service,CONGOSERV,Republic of the Congo
 RSS,Rossair,ROSS CHARTER,South Africa
 RST,Resort Air,RESORT AIR,United States
 RSU,AeroSur,AEROSUR,Bolivia
 RSV,Red Sky Ventures,RED SKY,Namibia
+RSY,I-Fly,,Russia
 RTE,Aeronorte,LUZAVIA,Portugal
+RTG,Rely AS,Reitan,Norway
 RTH,Artis,ARTHELICO,France
+RTL,Rheintalflug,,Austria
 RTM,Trans Am Compania,AERO TRANSAM,Ecuador
 RTN,Raytheon Aircraft Company,RAYTHEON,United States
 RTO,Arhabaev Tourism Airlines,ARTOAIR,Kazakhstan
@@ -4104,10 +5036,14 @@ RTV,Nortavia,TIC-TAC,Portugal
 RUA,Rwanda Airlines,,Rwanda
 RUC,Rutas Aéreas,RUTACA,Venezuela
 RUD,Air Anastasia,ANASTASIA,Ukraine
+RUE,Rainbow Air Euro,,United Kingdom
+RUF,Air 1st Aviation Co of OK,ROUGH RIDER,United States
 RUH,Rusich-T,,Russia
+RUK,Ryanair UK,BLUEMAX,United Kingdom
 RUM,Air Rum,AIR RUM,Sierra Leone
 RUN,ACT Havayollari,CARGO TURK,Turkey
 RUR,Rusaero,,Russia
+RUS,Cirrus Airlines,,Germany
 RUT,Reut Airways,YADID,Israel
 RUZ,Rusuertol,ROSTUERTOL,Russia
 RVC,Richards Aviation,RIVER CITY,United States
@@ -4122,6 +5058,7 @@ RVP,Air VIP,AEROVIP,Portugal
 RVQ,Aero Jet International,REVA AIR,United States
 RVR,Raven Air,RAVEN,United Kingdom
 RVT,Aircompany Veteran,AIR-VET,Armenia
+RVV,Reeve Aleutian Airways,,United States
 RWA,Rwanda Airways,,Rwanda
 RWB,Alliance Express Rwanda,,Rwanda
 RWC,Arrow Ecuador Arrowec,ARROWEC,Ecuador
@@ -4130,10 +5067,14 @@ RWE,Royal West Airlines,ROYAL WEST,United States
 RWG,C&M Airways,RED WING,United States
 RWL,RWL Luftfahrtgesellschaft,RHEINTRAINER,Germany
 RWS,Air Whitsunday,,Australia
+RWW,Fly Europa,,Spain
 RWY,Aerogroup 98 Limited,TYNWALD,United Kingdom
+RWZ,Red Wings,,Russia
 RXA,Regional Express,REX,Australia
 RXP,Royal Aviation Express,ROY EXPRESS,Canada
+RXR,REXAIR VIRTUEL,,France
 RXT,Aeroxtra,AERO-EXTRA,Mexico
+RXX,Express Air Charter,,Canada
 RYA,Ryan Air Services,RYAN AIR,United States
 RYB,Royal Bahrain Airlines,ROYAL BAHRAIN,Bahrain
 RYL,Royal Aruban Airlines,ROYAL ARUBAN,Aruba
@@ -4142,7 +5083,7 @@ RYR,Ryanair,RYANAIR,Ireland
 RYS,Buzz (Ryanair),MAGIC SUN,Poland
 RYT,Raya Jet,,Jordan
 RYZ,Ryazan State Air Enterprise,RYAZAN AIR,Russia
-RZ,Superna Airlines,YANGTZE RIVER,China
+RZA,Jet Fighter Flights,,Australia
 RZL,Aero Zambia,AERO ZAMBIA,Zambia
 RZN,Aero Zano,ZANO,Mexico
 RZO,SATA International,AIR AZORES,Portugal
@@ -4150,18 +5091,25 @@ RZR,Zephyr Express,RECOVERY,United States
 RZU,Zhersu Avia,ZHERSU AVIA,Kazakhstan
 RZV,Z-Avia,ZEDAVIA,Armenia
 RZZ,Anoka Air Charter,RED ZONE,United States
+SA1,Serbian Airlines,,Serbia
 SAA,South African Airways,SPRINGBOK,South Africa
 SAB,Sky Way Air,SKY WORKER,Kyrgyzstan
 SAC,SASCO Airlines,SASCO,Sudan
+SAE,SOCHI AIR EXPRESS,,Russia
 SAF,Singapore Air Force,SINGA,Singapore
 SAG,SOS Flygambulans,MEDICAL AIR,Sweden
 SAH,Sayakhat Airlines,SAYAKHAT,Kazakhstan
 SAI,Shaheen Air,SHAHEEN AIR,Pakistan
+SAJ,Golden Eagle Air Services (FAA),,Canada
+SAK,Red Arrows Display Squadron,,United Kingdom
+SAL,Spike Airlines,,United States
 SAM,SAM Colombia,SAM,Colombia
+SAN,Servicios Aereos Nacionales (SAN),,Ecuador
 SAO,Sahel Aviation Service,SAVSER,Mali
 SAP,Avia Jaynar,TOBOL,Kazakhstan
 SAQ,Safe Air Company,,Kenya
-SAS,Scandinavian Airlines,SCANDINAVIAN,Sweden, Denmark and Norway
+SAR,SprintAir Cargo,SPRINTAIR CARGO,Poland
+SAS,Scandinavian Airlines,SCANDINAVIAN,Sweden
 SAT,SATA Air Acores,SATA,Portugal
 SAU,United Aviation Services,UNISERVE,Spain
 SAV,Samal Air,,Kazakhstan
@@ -4178,6 +5126,7 @@ SBG,Sabre Incorporated,,United States
 SBH,Aerosaab,AEROSAAB,Mexico
 SBI,S7 Airlines,SIBERIAN AIRLINES,Russia
 SBJ,Trans Sahara Air,TRANS SAHARA,Nigeria
+SBK,Air Srpska,,Bosnia and Herzegovina
 SBL,Sobel Airlines of Ghana,SOBGHANA,Ghana
 SBM,SkyBahamas,SKY BAHAMAS,Bahamas
 SBO,Stabo Air,STABAIR,Zambia
@@ -4204,7 +5153,7 @@ SCM,American Jet International,SCREAMER,United States
 SCN,South American Airlines,SOUTH AMERICAN,Peru
 SCO,Helikopterservice Euro Air,SWEDCOPTER,Sweden
 SCP,Scorpio Aviation,SCORPIO,Egypt
-SCQ,OSM Aviation Academy,SCAVAC,Norway, Sweden and San Diego
+SCQ,OSM Aviation Academy,SCAVAC,Norway
 SCR,Silver Cloud Air,SILVER CLOUD,Germany
 SCS,South African Non Scheduled Airways,SOUTHERN CHARTERS,South Africa
 SCT,SAAB-Aircraft,SAAB-CRAFT,Sweden
@@ -4218,7 +5167,9 @@ SDC,Sunrise Airlines,SUNDANCE,United States
 SDD,Skymaster Air Taxi,SKY DANCE,United States
 SDE,Air Partners Corp.,STAMPEDE,Canada
 SDF,Sundorph Aeronautical Corporation,SUNDORPH,United States
+SDG,Star Air,HI STAR,India
 SDH,Servicio De Helicopteros,ARCOS,Spain
+SDI,San Dima Air,,United States
 SDJ,Club 328,SPACEJET,United Kingdom
 SDK,SADELCA - Sociedad Aérea Del Caquetá,SADELCA,Colombia
 SDL,Skydrift,SKYDRIFT,United Kingdom
@@ -4254,11 +5205,15 @@ SES,Servicio Aéreo Saltillo,SERVISAL,Mexico
 SET,SAETA,SAETA,Ecuador
 SEU,XL Airways France,STARWAY,France
 SEV,Serair Transworld Press,CARGOPRESS,Spain
+SEW,Skyward International Aviation,SKYWARD EXPRESS,Kenya
 SEY,Air Seychelles,SEYCHELLES,Seychelles
+SFA,SEFA,,France
+SFB,Air Sofia,,Bulgaria
 SFC,Shuswap Flight Centre,SHUSWAP,Canada
 SFE,Sefofane Air Charters,SEFOFANE,Botswana
 SFF,Safewings Aviation Company,SWIFTWING,United States
 SFG,Sun Freight Logistics,AERO GULF,Thailand
+SFH,North American Jet,STARFISH,United States
 SFJ,Star Flyer,STARFLYER,Japan
 SFL,Southflight Aviation,SOUTHFLIGHT,New Zealand
 SFM,A-Safar Air Services,AIR SAFAR,Nigeria
@@ -4268,19 +5223,25 @@ SFR,Safair,CARGO,South Africa
 SFS,Southern Frontier Air Transport,SOUTHERN FRONTIER,Canada
 SFT,Skyfreight,SKYFREIGHT,United States
 SFU,Solent Flight,SAINTS,United Kingdom
+SFW,Safi Airways,SAFI,AF
 SFX,S.K. Logistics,SWAMP FOX,United States
 SFY,Gulf Flite Center,SKY FLITE,United States
+SFZ,Pionair,SKYFORCE,Australia
 SGA,Air Saigon,AIR SAIGON,Vietnam
-SGB,Sky King, Inc.,SONGBIRD,United States
+SGB,Sky King Inc.,SONGBIRD,United States
 SGC,SGC Aviation,SAINT GEORGE,Austria
 SGD,Sky Gate International Aviation,AIR BISHKEK,Kyrgyzstan
 SGF,STAC Swiss Government Flights,STAC,Switzerland
+SGG,Senegal Airlines,,Senegal
 SGH,Servisair,SERVISAIR,United Kingdom
 SGI,Servicios Aéreos Agrícolas,SERAGRI,Chile
 SGK,Skyward Aviation,SKYWARD,Canada
+SGL,Sigma Airlines,SIGAIR,Kazakhstan
 SGM,Sky Aircraft Service,SIGMA,Netherlands
 SGN,Siam GA,SIAM,Thailand
 SGP,Sagolair Transportes Ejecutivos,SAGOLAIR,Spain
+SGQ,SaudiGulf Airlines,SAUDIGULF,SA
+SGR,Eastwind Airlines,,United States
 SGS,Saskatchewan Government Executive Air Service,SASKATCHEWAN,Canada
 SGT,Skygate,SKYGATE,Netherlands
 SGU,Sol del Paraguay,SOLPARAGUAYO,Paraguay
@@ -4295,6 +5256,7 @@ SHE,Shell Aircraft,SHELL,United Kingdom
 SHF,Royal Air Force,VORTEX,United Kingdom
 SHG,Shoprite Group,SHOP AIR,United Kingdom
 SHH,Airshare Holdings,AIRSHARE,United Kingdom
+SHI,Seoul Air International,,Republic of Korea
 SHJ,Sharjah Ruler's Flight,SHARJAH,United Arab Emirates
 SHK,Shorouk Air,,Egypt
 SHL,Samson Aviation,SAMSON,United Kingdom
@@ -4314,6 +5276,7 @@ SHY,Sky Airlines,ANTALYA BIRD,Turkey
 SIA,Singapore Airlines,SINGAPORE,Singapore
 SIB,Sibaviatrans,SIBAVIA,Russia
 SIC,SFS Aviation,SICHART,Thailand
+SID,Sideral Air Cargo,SIDERAL,BR
 SIE,Sierra Express,SEREX,United States
 SIH,Skynet Airlines,BLUEJET,Ireland
 SII,Aero Servicios Ejecutivos Internacionales,ASEISA,Mexico
@@ -4335,14 +5298,18 @@ SJA,Servicios Aéreos Especiales De Jalisco,SERVICIOJAL,Mexico
 SJC,Servicios Ejecutivos Continental,SERVIEJECUTIVO,Mexico
 SJE,Sunair 2001,SUNBIZ,South Africa
 SJJ,Spirit Aviation,SPIRIT JET,United States
+SJK,Nusantara Air Charter,NUSANTARA,Indonesia
 SJL,Servicios Especiales Del Pacifico Jalisco,SERVICIOS JALISCO,Mexico
 SJM,Sino Jet Management,SINO SKY,China
 SJN,Air San Juan,SAN JUAN,United States
 SJO,Spring Airlines Japan,JEY SPRING,Japan
+SJS,Southjet,,United States
 SJT,Swiss Jet,SWISS JET,Switzerland
+SJU,Skyjet Airlines,,Uganda
 SJX,Starlux Airlines,STARWALKER,Taiwan
 SJY,Sriwijaya Air,SRIWIJAYA,Indonesia
 SKA,Rio Air Express,RIO EXPRESS,Brazil
+SKB,Skybus Airlines,,United States
 SKC,Skymaster Airlines,SKYMASTER AIR,Brazil
 SKD,Sky Harbor Air Service,SKY DAWG,United States
 SKE,Sky Tours,SKYISLE,United States
@@ -4355,6 +5322,7 @@ SKL,Skycharter (Malton),SKYCHARTER,Canada
 SKM,Fayetteville Flying Service and Scheduled Skyways System,SKYTEM,United States
 SKN,Skyline Aviation Services,SKYLINER,United States
 SKO,Scottish Airways Flyers,SKYWORK,United Kingdom
+SKP,Aero-North Aviation Services,,Canada
 SKQ,Labcorp,SKYLAB,United States
 SKR,Skyscapes Air Charters,SKYSCAPES,South Africa
 SKS,Sky Service,SKY SERVICE,Belgium
@@ -4367,18 +5335,22 @@ SKY,Skymark Airlines,SKYMARK,Japan
 SKZ,Skyway Enterprises,SKYWAY-INC,United States
 SLA,Sierra National Airlines,SELAIR,Sierra Leone
 SLB,Slok Air,SLOK AIR,Nigeria
+SLC,Salsa d\\'Haiti,,Haiti
 SLD,Silver Air,SILVERLINE,Czech Republic
 SLE,Streamline,SLIPSTREAM,South Africa
 SLF,Starfly,ELISTARFLY,Italy
 SLG,Saskatchewan Government,LIFEGUARD,Canada
 SLH,Silverhawk Aviation,SILVERHAWK,United States
 SLI,Aeroméxico Connect,COSTERA,Mexico
+SLJ,SLAM Lavori Aerei SrL,SLAMAIR,Italy
 SLK,SilkAir,SILKAIR,Singapore
 SLL,Slovak Airlines,SLOV LINE,Slovakia
 SLM,Surinam Airways,SURINAM,Suriname
 SLN,Sloane Aviation,SLOANE,United Kingdom
 SLO,Edgartown Air,SLOW,United States
 SLP,Salpa Aviation,SALPA,Sudan
+SLQ,Skylink Express Inc,SKYLINK,Canada
+SLR,Silverstone Air Services,SILVERSTONE,Kenya
 SLS,Servicios Aéreos Slainte,SERVICIOS SLAINTE,Mexico
 SLU,Avio Sluzba,AVIO SLUZBA,Serbia
 SLV,Stella Aviation,AVISTELLA,Mauritania
@@ -4398,6 +5370,7 @@ SMJ,Avient Aviation,AVAVIA,Zimbabwe
 SMK,Semeyavia,ERTIS,Kazakhstan
 SML,Smith Air (1976),SMITH AIR,Canada
 SMM,Summit Airlines,SUMMIT-AIR,United States
+SMO,Servicios Aereos Automotriz SA de CV,SERVIAUTOMOTRIZ,Mexico
 SMQ,Samar Air,SAMAR AIR,Tajikistan
 SMR,Somon Air,SOMON AIR,Tajikistan
 SMS,Linhas Aéreas Santomenses,SANTOMENSES,São Tomé and Príncipe
@@ -4430,6 +5403,7 @@ SNV,Sudanese States Aviation,SUDANESE,Sudan
 SNW,Sun West Airlines,SUN WEST,United States
 SNX,Sun Air Aviation Services,SUNEX,Canada
 SNY,Air Sandy,AIR SANDY,Canada
+SOA,Southern Air Charter,,Bahamas
 SOB,Stabo Freight,STABO,Zambia
 SOC,Southern Cargo Air Lines,,Russia
 SOD,Aerolíneas Sol,ALSOL,Mexico
@@ -4483,7 +5457,10 @@ SQH,SeaPort Airlines,SASQUATCH,United States
 SQL,Servicos De Alquiler,ALQUILER,Mexico
 SQP,SkyUp,SKYUP,Ukraine
 SQR,Alsaqer Aviation,ALSAQER AVIATION,Libya
+SQS,Susi Air,SKY QUEEN,Indonesia
+SQU,Bechtel Corp,REMUDO,United States
 SRA,Sair Aviation,SAIR,Canada
+SRB,Solar Air,,Thailand
 SRC,Searca,SEARCA,Colombia
 SRD,Search and Rescue 22,,United Kingdom
 SRE,Fly Jetstream Aviation,STREAMJET,South Africa
@@ -4494,6 +5471,7 @@ SRI,Air Safaris and Services,AIRSAFARI,New Zealand
 SRJ,C Air Jet Airlines,SYRJET,Syrian Arab Republic
 SRK,Sky Work Airlines,SKYFOX,Switzerland
 SRL,Servicios Aeronáuticos Aero Personal,SERVICIOS PERSONAL,Mexico
+SRM,Stars de Mexico SA de CV,TARMEX,Mexico
 SRN,Sirair,SIRAIR,Russia
 SRO,Servicios Aéreos Ejecutivos Saereo,SAEREO,Ecuador
 SRP,Polizeihubschauberstaffel Rheinland-Pfalz,SPERBER,Germany
@@ -4507,6 +5485,7 @@ SRW,Sarit Airlines,SARIA,Sudan
 SRX,Sierra Expressway Airlines,SIERRA EX,United States
 SRY,As-Aero,,Armenia
 SRZ,Strato Air Services,STRATO,South Africa
+SSA,All America US,,United States
 SSB,Sasair,SASIR,Canada
 SSC,Southern Seaplane,SOUTHERN SKIES,United States
 SSD,Star Service International,STAR SERVICE,France
@@ -4515,15 +5494,19 @@ SSF,Severstal Air Company,SEVERSTAL,Russia
 SSG,Slovak Government Flying Service,SLOVAK GOVERNMENT,Slovakia
 SSH,Heritage Flight (Valley Air Services),SNOWSHOE,United States
 SSI,Vision Airlines,SUPER JET,Nigeria
+SSJ,KrasAvia,SIBERIAN SKY,RU
 SSK,Skystar International,SKYSTAR,United States
 SSL,Air Sultan,SIERRA SULTAN,Sierra Leone
+SSM,Aero 1 Pro-Jet,,Canada
 SSN,Airquarius Air Charter,SUNSTREAM,South Africa
 SSO,Special Scope Limited,DOPE,United Kingdom
 SSP,Starspeed,STARSPEED,United Kingdom
 SSQ,Sunstate Airlines,SUNSTATE,Australia
+SSR,Sardinian Sky Aviation SRL,SARDINIAN,Italy
 SSS,SAESA,SAESA,Spain
 SST,Sunwest Airlines,SUNFLIGHT,Canada
 SSU,SASCA,SASCA,Venezuela
+SSV,Skyservice Airlines,,Canada
 SSW,Streamline Aviation,STREAMLINE,United Kingdom
 SSX,Lynx Aviation,SHASTA,United States
 SSY,Sky Aviation,SIERRA SKY,Sierra Leone
@@ -4534,7 +5517,7 @@ STC,Stadium City Limited,STADIUM,United Kingdom
 STD,Servicios De Aerotransportacion De Aguascalientes,AERO AGUASCALINETES,Mexico
 STE,Semitool Europe,SEMITRANS,United Kingdom
 STF,SFT-Sudanese Flight,,Sudan
-STG,Sedalia, Marshall, Boonville Stage Line,STAGE,United States
+STG,Sedalia Marshall Boonville Stage Line,STAGE,United States
 STH,South-Airlines,,Armenia
 STI,Sontair,SONTAIR,Canada
 STJ,Sella Aviation,STELLAVIA,Netherlands
@@ -4542,8 +5525,10 @@ STK,Aeropac,SAT PAK,United States
 STL,Stapleford Flight Centre,STAPLEFORD,United Kingdom
 STN,RAF St Athan,SAINT ATHAN,United Kingdom
 STO,Streamline Ops,SLOPS,Russia
+STP,STP Airways,,Sao Tome and Principe
 STQ,Star Air,STERA,Indonesia
 STR,Red Star,STARLINE,United Arab Emirates
+STS,Starling Airlines Spain,,Spain
 STT,Alpha Star Charter,STAR CHARTER,Saudi Arabia
 STU,Servicios de Transportes Aéreos Fueguinos,FUEGUINO,Argentina
 STV,Saturn Aviation,SATURN,United States
@@ -4575,6 +5560,7 @@ SVB,Siavia,SIAVIA,Slovenia
 SVD,St. Vincent Grenadines Air (1990),GRENADINES,Saint Vincent and the Grenadines
 SVE,Aero Servicios Expecializados,AEROESPECIAL,Mexico
 SVF,Swedish Armed Forces,SWEDEFORCE,Sweden
+SVG,SVG Air,,Saint Vincent and the Grenadines
 SVH,Sterling Helicopters,SILVER,United Kingdom
 SVI,Servicios De Transporte Aéreo,SETRA,Mexico
 SVJ,Silver Air,,Djibouti
@@ -4602,7 +5588,9 @@ SWI,Sunworld Airlines,SUNWORLD,United States
 SWJ,StatesWest Airlines,STATES,United States
 SWK,General Aerospace,SKYWALKER,Canada
 SWL,Trans Jet Airways,TRANSJET,Sweden
+SWM,Sky Angkor Airlines (ZA),,Cambodia
 SWN,West Air Sweden,AIR SWEDEN,Sweden
+SWO,Surninam International Victory Airline,,Suriname
 SWP,Star Work Sky,STAR WORK,Italy
 SWQ,Swift Air (Interstate Equipment Leasing),SWIFTFLIGHT,United States
 SWR,Swiss International Air Lines,SWISS,Switzerland
@@ -4618,14 +5606,18 @@ SXA,Southern Cross Aviation,FERRY,United States
 SXC,Sky Exec Aviation Services,SKY EXEC,Nigeria
 SXD,Sunexpress Deutschland,SUNRISE,Germany
 SXE,Southeast Express Airlines,DOGWOOD EXPRESS,United States
+SXI,Southern Cross International,SOUTHERN CROSS,Netherlands
 SXL,Skyline Flight,SKYLINE,United States
 SXM,Servicios Aéreos Especializados Mexicanos,SERVIMEX,Mexico
 SXN,SaxonAir,SAXONAIR,United Kingdom
+SXP,Sky Express,,Poland
+SXR,Sky Express,,Russia
 SXS,SunExpress,SUNEXPRESS,Turkey
 SXT,Servicios de Taxi Aereos,SERTAXI,Mexico
 SXX,Satellite Aero,SATELLITE EXPRESS,United States
 SXY,Safari Express Cargo,SAFARI EXPRESS,Kenya
 SYA,Skyways,LINEAS CARDINAL,Argentina
+SYB,Skyservice Business Aviation,SKYBIZ,Canada
 SYC,Systec 2000,SYSTEC,United States
 SYE,Sheba Aviation,,Yemen
 SYF,Sky One Express Airlines,SKY FIRST,United States
@@ -4643,20 +5635,32 @@ SYV,Special Aviation Systems,SPECIAL SYSTEM,United States
 SYX,Skywalk Airlines,SKYWAY-EX,United States
 SYY,South African Historic Flight,SKY COACH,South Africa
 SYZ,Zil Air,ZIL AIR,Seychelles
+SZA,Aerolineas De El Salvador,,El Salvador
 SZB,Samoa Air,SAMOA,Samoa
+SZL,Swaziland Airlink,,Swaziland
 SZN,Air Senegal,AIR SENEGAL,Senegal
+SZS,SAS Ireland,SPINNAKER,Ireland
 SZT,Servicios Aeronáuticos Z,AERO ZEE,Mexico
+SZZ,SUR Lineas Aereas,,Argentina
+T&O,Tom's & co airliners,,France
+T33,THREE,,China
+T9P,Tomp Airlines,,Chile
 TAA,Aeroservicios de La Costa,AERO COSTA,Mexico
+TAB,Transportes Aeronauticos del Bajio S.A. de C.V.,TRANS-BAJIO,Mexico
 TAC,Turbot Air Cargo,TURBOT,Senegal
 TAD,Transporte Aéreo Dominicano,TRANS DOMINICAN,Dominican Republic
 TAE,TAME,TAME,Ecuador
 TAG,TAG Aviation USA,TAG U-S,United States
+TAH,Air Moorea,,France
+TAI,Avianca El Salvador,TACA,El Salvador
 TAJ,Tunisavia,TUNISAVIA,Tunisia
+TAK,Tatarstan Airlines,,Russia
 TAL,Talair,TALAIR,Papua New Guinea
 TAM,LATAM Brasil,TAM,Brazil
 TAN,Zanair,ZANAIR,Tanzania
 TAO,Aeromar,TRANS-AEROMAR,Mexico
 TAP,TAP Portugal,AIR PORTUGAL,Portugal
+TAQ,Taunus Air Gmbh,,Germany
 TAR,Tunisair,TUNAIR,Tunisia
 TAS,Lotus Air,LOTUS FLOWER,Egypt
 TAT,Grupo TACA,TACA-COSTARICA,Costa Rica
@@ -4670,6 +5674,7 @@ TBD,Thunderbird Tours,ORCA,Canada
 TBG,Tropical Airways,,Haiti
 TBH,Trinity Air Bahamas,,Bahamas
 TBI,TAB Express International,TAB INTERNATIONAL,United States
+TBJ,TAG Aviation Asia,TAG JET,Hong Kong
 TBL,Aerotrebol,AEROTREBOL,Mexico
 TBM,Taban Air Lines,TABAN AIR,Iran
 TBN,Teebah Airlines,TEEBAH,Sierra Leone
@@ -4677,6 +5682,7 @@ TBO,Aero Taxi de Los Cabos,AERO CABOS,Mexico
 TBR,Tubelair,TUBELAIR,Tunisia
 TBS,Timbis Air,,Kenya
 TBX,Tobago Express,TABEX,Trinidad and Tobago
+TBZ,TrasBrasil,,Brazil
 TCA,Tropican Air Services,TROPICANA,Egypt
 TCB,Transporte Aereo De Colombia,AERO COLOMBIA,Colombia
 TCC,Trans Continental Airlines,TRANSCAL,Sudan
@@ -4695,13 +5701,16 @@ TCR,Lanaes Aereas Trans Costa Rica,TICOS,Costa Rica
 TCT,Transcontinental Sur,TRANS-CONT,Uruguay
 TCU,Transglobal Airways Corporation,TRANSGLOBAL,Philippines
 TCV,TACV,CABOVERDE,Cape Verde
+TCW,Thomas Cook Airlines,,Belgium
 TCX,Thomas Cook Airlines,THOMAS COOK,United Kingdom
 TCY,Twin Cities Air Service,TWIN CITY,United States
 TDA,Trend Aviation,TREND AIR,United States
 TDB,Welch Aviation,THUNDER BAY,United States
+TDC,Tadair,,Spain
 TDE,Tellavia / Flight One,TELLURIDE,United States
 TDG,Air Cargo Express,TURBO DOG,United States
 TDI,Transportes Aéreos de Ixtlán,TRANSIXTLAN,Mexico
+TDK,Transavia Denmark,,Denmark
 TDM,Tandem Aero,TANDEM,Moldova
 TDO,TRADO,TRADO,Dominican Republic
 TDR,Trade Air,TRADEAIR,Croatia
@@ -4717,6 +5726,7 @@ TEE,West Freugh DTEO,TEEBIRD,United Kingdom
 TEF,Tecnicas Fotograficas,TECFOTO,Spain
 TEH,Tempelhof Airways,TEMPELHOF,United States
 TEJ,AeroJet,,Angola
+TEK,Aero-Tech Services Inc,ATECH,United States
 TEL,Telford Aviation,TELFORD,United States
 TEM,Tech-Mont Helicopter Company,TECHMONT,Slovakia
 TEN,Tennessee Airways,TENNESSEE,United States
@@ -4724,6 +5734,7 @@ TEP,Transeuropean Airlines,TRANSEURLINE,Russia
 TER,Territorial Airlines,TERRI-AIRE,United States
 TES,Taespejo Portugal LDA,Tesaban,Portugal
 TET,Tepavia-Trans Airlines,TEPAVIA,Moldova
+TEU,TAG Aviation Malta Ltd,TAG MALTA,Malta
 TEW,Airteam Charter,TEAMWORK,South Africa
 TEX,Catex,CATEX,France
 TEZ,TezJet Airlines,,Kyrgyzstan
@@ -4737,9 +5748,12 @@ TFK,Transafrik International,,São Tomé and Príncipe
 TFL,TUI Airlines Netherlands,ORANGE,Netherlands
 TFN,Norwegian Aviation College,SPIRIT,Norway
 TFO,Transportes Aéreos del Pacífico,TRANSPORTES PACIFICO,Mexico
+TFR,Air Freight NZ Cargo,TOLL FREIGHT,New Zealand
 TFT,Thai Flying Service,THAI FLYING,Thailand
 TFU,213th Flight Unit,THJY,Russia
+TFX,Toll Priority,TOLL EXPRESS,AU
 TFY,Tayside Aviation,TAYSIDE,United Kingdom
+TGA,Air Togo,,Togo
 TGC,TG Aviation,THANET,United Kingdom
 TGE,Trabajos Aéreos,TASA,Spain
 TGG,Tigerair Australia,TIGGOZ,Australia
@@ -4748,6 +5762,7 @@ TGM,TAG Aviation Espana,TAG ESPANA,Spain
 TGN,Trigana Air Service,TRIGANA,Indonesia
 TGO,Transport Canada,TRANSPORT,Canada
 TGT,SAAB Nyge Aero,TARGET,Sweden
+TGU,TAG Airlines,CHAPIN,GT
 TGW,Scoot,SCOOTER,Singapore
 TGX,Transair Gabon,TRANSGABON,Gabon
 TGY,Trans Guyana Airways,TRANS GUYANA,Guyana
@@ -4759,6 +5774,7 @@ THD,Thai Smile Airways,THAI SMILE,Thailand
 THE,Toumai Air Tchad,TOUMAI AIR,Chad
 THF,Touraine Helicoptere,TOURAINE HELICO,France
 THG,Thai Global Airline,THAI GLOBAL,Thailand
+THI,TransHolding,,Brazil
 THJ,Thai Jet Intergroup,THAI JET,Thailand
 THK,Turk Hava Kurumu Hava Taksi Isletmesi,HUR KUS,Turkey
 THM,Airmark Aviation,THAI AIRMARK,Thailand
@@ -4775,14 +5791,20 @@ TIB,TRIP Linhas Aéreas,TRIP,Brazil
 TIC,Travel International Air Charters,TRAVEL INTERNATIONAL,Zambia
 TID,Air Tindi,,Canada
 TIE,Time Air,TIME AIR,Czech Republic
+TIG,Tiger Helicopters Ltd,TIGRIS,United Kingdom
 TIH,S C Ion Tiriac,TIRIAC AIR,Romania
 TIK,Tic Air,TICAIR,Australia
+TIL,Tajikistan International Airlines,,Tajikistan
 TIM,TEAM Linhas Aéreas,TEAM BRASIL,Brazil
 TIN,Taino Tours,TAINO,Dominican Republic
 TIP,C and M Aviation,TRANSPAC,United States
 TIR,Antair,ANTAIR,Mexico
 TIS,Tesis,TESIS,Russia
+TIV,Thrive Aviation,THRIVE,United States
 TIW,Transcarga Intl Airways,TIACA,Venezuela
+TJA,T.J. Air,,United States
+TJD,Aliserio,ALISERIO,Italy
+TJJ,Top Jets,THUNDERBOLT,Bulgaria
 TJK,Tajikair,TAJIKAIR,Tajikistan
 TJN,Tien-Shan,NERON,Kazakhstan
 TJS,Tyrolean Jet Services,TYROLJET,Austria
@@ -4791,14 +5813,18 @@ TKC,Tikal Jets Airlines,TIKAL,Guatemala
 TKE,Take Air Line,ISLAND BIRD,France
 TKJ,Tarkim Aviation,TARKIM AVIATION,Turkey
 TKK,FlyADVANCED,,United States
+TKM,JM Family Aviation,TACOMA,United States
 TKR,Canadian Interagency Forest Fire Centre,TANKER,Canada
+TKS,Tomsk-Avia,,Russia
 TKX,Tropical International Airways,TROPEXPRESS,Saint Kitts and Nevis
+TKY,Thai Sky Airlines,,Thailand
 TLA,Translift Airways,TRANSLIFT,Ireland
 TLB,Atlantique Air Assistance,TRIPLE-A,France
 TLC,Caribbean Express,CARIB-X,United States
 TLD,Aereo Taxi Autlan,AEREO AUTLAN,Mexico
 TLE,Aero Util,AEROUTIL,Mexico
 TLF,Transport Africa,TRANS-LEONE,Sierra Leone
+TLI,TL Aviation,SPIRIT,Germany
 TLK,Starlink Aviation,STARLINK,Canada
 TLL,Trans Atlantic Airlines,ATLANTIC LEONE,Sierra Leone
 TLM,Thai Lion Mentari,MENTARI,Thailand
@@ -4813,6 +5839,7 @@ TLW,Teamline Air,Teamline,Austria
 TLX,Telesis Transair,TELESIS,United States
 TLY,Top Fly,TOPFLY,Spain
 TMA,Trans Mediterranean Airlines,TANGO LIMA,Lebanon
+TMB,Volato,TOMBO,United States
 TMC,Travel Management Company,TRAIL BLAZER,United States
 TMD,Transmandu,TRANSMANDU,Venezuela
 TME,Aero Taxi del Centro de Mexico,TAXICENTRO,Mexico
@@ -4822,14 +5849,17 @@ TMI,Tamir Airways,TAMIRWAYS,Israel
 TMK,Tomahawk Airways,TOMAHAWK,United States
 TML,Transports et Travaux Aériens de Madagascar,TAM AIRLINE,Madagascar
 TMM,TMC Airlines,WILLOW RUN,United States
+TMN,Tasman Cargo Airlines,TASMAN,AU
 TMP,Arizona Express Airlines,TEMPE,United States
 TMQ,TRAM,TRAM AIR,Mauritania
 TMR,Timberline Air,TIMBER,Canada
 TMS,Temsco Helicopters,TEMSCO,United States
 TMT,Trans Midwest Airlines,TRANS MIDWEST,United States
+TMW,Trans Maldivian Airways,,Maldives
 TMX,Tramon Air,TRAMON,South Africa
 TMY,Transportes Aéreos del Mundo Maya,MUNDO MAYA,Mexico
 TMZ,Transporte Amazonair,TRANS AMAZON,Venezuela
+TNA,TransAsia Airways,,Taiwan
 TNB,Trans Air-Benin,TRANS-BENIN,Benin
 TNC,National Aviation Consultants,NATCOM,Canada
 TND,Aero Taxis Cessna,TAXIS CESSNA,Mexico
@@ -4842,7 +5872,9 @@ TNM,Tiara Air,TIARA,Aruba
 TNO,Aerotransporte de Carga Union,AEROUNION,Mexico
 TNP,Transped Aviation,TRANSPED,Austria
 TNR,Tanana Air Services,TAN AIR,United States
+TNS,Transilvania,,Romania
 TNT,Trans North Turbo Air,TRANS NORTH,Canada
+TNU,TransNusa Air,,Indonesia
 TNV,Transnorthern,TRANSNORTHERN,United States
 TNW,Trans Nation Airways,TRANS-NATION,Ethiopia
 TNX,Trener Ltd,TRAINER,Hungary
@@ -4863,12 +5895,15 @@ TOT,Totavia,,Canada
 TOW,AirTanker Services,TOWLINE,United Kingdom
 TOX,Neosiam Airways,SKY KINGDOM,Thailand
 TOY,Toyota Canada,TOYOTA,Canada
+TP3,TROPICAL LINHAS AEREAS,,Brazil
+TP6,Trans Pas Air,,United States
 TPA,TAMPA,TAMPA,Colombia
 TPB,Aero Tropical,AERO TROPICAL,Angola
 TPC,Air Calédonie,AIRCAL,France
 TPD,Top Speed,TOP SPEED,Austria
 TPF,Taxis Aéreos del Pacífico,TAXIPACIFICO,Mexico
 TPG,Transportes Aéreos Pegaso,TRANSPEGASO,Mexico
+TPJ,Tempus Jets Inc,TEMPUS JETS,United States
 TPK,Air Horizon,TCHAD-HORIZON,Chad
 TPL,TAR Interpilot,INTERPILOT,Mauritania
 TPM,Transpaís Aéreo,TRANSPAIS,Mexico
@@ -4885,6 +5920,7 @@ TPY,Trans-Provincial Airlines,TRANS PROVINCIAL,Canada
 TPZ,Transportes La Paz,TRANSPAZ,Mexico
 TQE,Taxair Mexiqienses,TAXAIR,Mexico
 TQF,United Kingdom Royal VIP Flights,RAINBOW,United Kingdom
+TQM,JM Family Aviation,,United States
 TQN,Taquan Air Services,TAQUAN,United States
 TQR,Transportación Aérea De Querétaro,TRANSQUERETARO,Mexico
 TQS,Aeroturquesa,AEROTURQUESA,Mexico
@@ -4903,11 +5939,15 @@ TRM,Transport Aerien de Mauritanie,SOTRANS,Mauritania
 TRN,Servicios Aéreos Corporativos,AEROTRON,Mauritania
 TRO,Tropic Airlines-Air Molokai,MOLOKAI,United States
 TRP,Maryland State Police,TROOPER,United States
+TRQ,Turdus Airways,,Netherland
 TRR,Tramson Limited,TRAMSON,Sudan
+TRS,AirTran Airways,,United States
 TRT,Trans Arabian Air Transport,TRANS ARABIAN,Sudan
 TRU,Triangle Airline (Uganda),TRI AIR,Uganda
 TRW,Transwestern Airlines of Utah,TRANS-WEST,United States
+TRX,TATSA - Transportes Aereos Terrestres SA,TRANS-TERRESTRES,Mexico
 TRY,Tristar Airlines,TRISTAR AIR,United States
+TRZ,TransMeridian Airlines,,United States
 TSA,Transair France,AIRTRAF,France
 TSC,Air Transat,AIR TRANSAT,Canada
 TSD,TAF-Linhas Aéreas,TAFI,Brazil
@@ -4937,15 +5977,19 @@ TTC,Transteco,TRANSTECO,Angola
 TTE,Avcenter,TETON,United States
 TTF,224th Flight Unit,CARGO UNIT,Russia
 TTH,Tarhan Tower Airlines,,Turkey
+TTJ,Tatra Jet,TATRA,SK
 TTL,Total Linhas Aéreas,TOTAL,Brazil
 TTM,Societe Tout Transport Mauritanien,TOUT-AIR,Mauritania
 TTN,Absolute Flight Services,TITANIUM,South Africa
 TTP,Triple O Aviation,MIGHTY WING,Nigeria
 TTR,Transportaciones Y Servicios Aéreos,TRANSPORTACIONES,Mexico
 TTS,Transporte Aéreo Técnico Ejecutivo,TECNICO,Mexico
+TTU,Tantalus Air,TANTALUS,Canada
 TTW,Tigerair Taiwan,SMART CAT,Taiwan
 TTX,Alliance Air Charters,TWISTER,United States
+TTZ,Transair,,Canada
 TUA,Turkmenhovayollary,TURKMENISTAN,Turkmenistan
+TUB,TUI Airlines Belgium,,Belgium
 TUC,Turismo Aéreo de Chile,TURICHILE,Chile
 TUD,Flight Alaska,TUNDRA,United States
 TUG,Turkmenistan Airlines,,Turkmenistan
@@ -4953,6 +5997,7 @@ TUI,Tuninter,,Tunisia
 TUK,Ocean Wings Commuter Service,TUCKERNUCK,United States
 TUL,Tulpar Air,URSAL,Russia
 TUM,Tyumenspecavia,TUMTEL,Russia
+TUN,Air Tungaru,,Kiribati
 TUO,Taxi Aéreo Turístico,TURISTICO,Mexico
 TUP,Aviastar-Tu,TUPOLEVAIR,Russia
 TUR,ATUR,,Ecuador
@@ -4967,17 +6012,23 @@ TVI,Tiramavia,TIRAMAVIA,Moldova
 TVJ,Thai Vietjet Air,THAIVIET JET,Thailand
 TVL,Travel Service,TRAVEL SERVICE,Hungary
 TVO,Transavio,TRANS-BALLERIO,Italy
+TVP,Smartwings Poland,JET TRAVEL,Poland
 TVR,Tavrey Airlines,TAVREY,Ukraine
 TVS,Smartwings,SKYTRAVEL,Czech Republic
+TVV,Travira Air,PARAMITA,Indonesia
+TWA,Trans World Airlines,,United States
 TWB,T'way Air,TWAYAIR,Republic of Korea
+TWD,Turkish Wings Domestic,,Turkey
 TWE,Transwede Airways,TRANSWEDE,Sweden
 TWF,247 Jet Ltd,CLOUD RUNNER,United Kingdom
 TWG,air-taxi Europe,TWINGOOSE,Germany
+TWI,Tailwind Airlines,TAILWIND,TR
 TWJ,Twinjet Aircraft Sales,,United Kingdom
 TWL,Tradewinds Aviation,TRADEWINDS CANADA,Canada
 TWM,Transairways,,Mozambique
 TWN,Avialeasing Aviation Company,TWINARROW,Uzbekistan
 TWO,Twente Airlines,COLIBRI,Netherlands
+TWT,Transwisata Air,TRANSWISATA,Indonesia
 TWW,Trans Air Welwitchia,WELWITCHIA,Angola
 TWY,Sunset Aviation,TWILIGHT,United States
 TXA,Texair Charter,OKAY AIR,United States
@@ -4991,21 +6042,27 @@ TXL,Taxi Aéreo Cozatl,TAXI COZATL,Mexico
 TXM,Taxi Aéreo de México,TAXIMEX,Mexico
 TXN,Texas National Airlines,TEXAS NATIONAL,United States
 TXO,Taxis Aéreos de Sinaloa,TAXIS SINALOA,Mexico
+TXP,Texas Spirit,,United States
 TXR,Taxirey,TAXIREY,Mexico
 TXS,Texas Airlines,TEXAIR,United States
 TXT,Texas Air Charters,TEXAS CHARTER,United States
 TXU,ATESA Aerotaxis Ecuatorianos,ATESA,Ecuador
 TXV,Puerto Vallarta Taxi Aéreo,TAXIVALLARTA,Mexico
+TXW,Texas Wings,,United States
+TXX,Austin Express,,United States
 TXZ,Tex Star Air Freight,TEX STAR,United States
 TYA,NordStar,TAIMYR,Russia
 TYF,Tayflite,TAYFLITE,United Kingdom
 TYG,Trygg-Flyg,TRYGG,Sweden
 TYJ,TJS Malta Ltd.,TYROLMALTA,Malta
 TYR,Tyrolean Airways,TYROLEAN,Austria
+TYS,TransHolding System,,Brazil
 TYW,Tyrol Air Ambulance,TYROL AMBULANCE,Austria
 TZA,Aero Tomza,AERO TOMZA,Mexico
 TZE,Transporte Aéreo Ernesto Saenz,TRANSPORTE SAENZ,Mexico
 TZK,Tajikistan International Airlines,TAJIKSTAN,Tajikistan
+TZP,ZIPAIR Tokyo,ZIPPY,Japan
+TZS,TCA,TOKA,Georgia
 TZT,Air Zambezi,ZAMBEZI,Zimbabwe
 TZU,Servicios Aéreos Tamazula,TAMAZULA,Mexico
 UAA,University Air Squadron,,United Kingdom
@@ -5015,17 +6072,21 @@ UAD,University Air Squadron,,United Kingdom
 UAE,Emirates Airlines,EMIRATES,United Arab Emirates
 UAF,United Arab Emirates Air Force,UNIFORCE,United Arab Emirates
 UAG,Afra Airlines,AFRALINE,Ghana
-UAH,Air Experience Flight, Cranwell,,United Kingdom
+UAH,Air Experience Flight Cranwell,,United Kingdom
 UAI,Union Africaine des Transports,UNAIR,Ivory Coast
 UAJ,University Air Squadron,,United Kingdom
 UAK,Kiev Aviation Plant,AVIATION PLANT,Ukraine
 UAL,United Airlines,UNITED,United States
 UAR,Aerostar Airlines,AEROSTAR,Ukraine
 UAS,University Air Squadron,,United Kingdom
+UAT,Ukraine Atlantic,,Ukraine
+UAW,UAS/AEF St Athan,,United Kingdom
+UAY,University of Birmingham Air Squadron (RAF),,United Kingdom
 UBA,Myanma Airways,UNIONAIR,Myanmar
 UBD,United Airways,UNITED BANGLADESH,Bangladesh
 UBG,US-Bangla Airlines,BANGLA STAR,Bangladesh
 UCA,CommutAir,COMMUTAIR,United States
+UCB,United Caribbean Airlines,EAGLE EYE,Curaçao
 UCC,Uganda Air Cargo,UGANDA CARGO,Uganda
 UCG,Uniworld Air Cargo,UNIWORLD,Panama
 UCH,US Airports Air Charter,US CHARTER,United States
@@ -5038,6 +6099,8 @@ UDC,DonbassAero,DONBASS AERO,Ukraine
 UDN,Dniproavia,DNIEPRO,Ukraine
 UEA,United Eagle Airlines,UNITED EAGLE,China
 UED,Air LA,AIR L-A,United States
+UEE,United Eagle,EAGLE SLOVENIA,Slovenia
+UEJ,Jetcorp,,United States
 UES,Ues-Avia Aircompany,AVIASYSTEM,Ukraine
 UEU,United European Airlines,UNITED EUROPEAN,Romania
 UFA,State Flight Academy of Ukraine,FLIGHT ACADEMY,Ukraine
@@ -5048,10 +6111,12 @@ UGD,Uganda Airlines,CRESTED,Uganda
 UGL,Inter-Island Air,UGLY VAN,United States
 UGN,Yuzhnaya Aircompany,PLUTON,Kazakhstan
 UGP,Shar Ink,SHARINK,Russia
+UGX,East African,,Uganda
 UHL,Ukrainian Helicopters,UKRAINE COPTERS,Ukraine
 UHS,Ulyanovsk Higher Civil Aviation School,PILOT AIR,Russia
 UIA,UNI Air,GLORY,Taiwan
 UIT,University of Tromsø School of Aviation,ARCTIC,Norway
+UJC,Ultimate Jetcharters,ULTIMATE,United States
 UJR,Universal Jet Rental de Mexico,UNIVERSAL JET,Mexico
 UJT,Universal Jet Aviation,UNI-JET,United States
 UJX,Atlas Ukraine Airlines,ATLAS UKRAINE,Ukraine
@@ -5063,8 +6128,12 @@ UKN,Ukraine Air Enterprise,ENTERPRISE UKRAINE,Ukraine
 UKP,National Police Air Service,POLICE,United Kingdom
 UKR,Air Ukraine,AIR UKRAINE,Ukraine
 UKS,Ukrainian Cargo Airways,CARGOTRANS,Ukraine
+UKT,Uktus Avia-Company,UKTUS,Russia
 UKU,Second Sverdlovsk Air Enterprise,PYSHMA,Russia
 UKW,Lviv Airlines,UKRAINE WEST,Ukraine
+UKZ,Fly Zoom,,United Kingdom
+ULA,Zuliana de Aviacion,,Venezuela
+ULC,Albinati Aviation Ltd,ALBI,Malta
 ULH,Ultimate HELI,ULTIMATEHELI,South Africa
 ULR,Ultimate Air,VIPER,South Africa
 ULS,Carroll Air Service,ULSTER,United States
@@ -5072,6 +6141,8 @@ ULT,Ultrair,ULTRAIR,United States
 UMA,Líneas Aéreas del Humaya,HUMAYA,Mexico
 UMB,Air Umbria,AIR UMBRIA,Italy
 UMK,Yuzhmashavia,YUZMASH,Ukraine
+UMS,Unitemp-M,,Russia
+UNA,BAA Jet Management Ltd,UNITED ASIA,Hong Kong
 UNC,Uni-Fly,UNICOPTER,Denmark
 UND,Atuneros Unidos de California,ATUNEROS UNIDOS,Mexico
 UNF,Union Flights,UNION FLIGHTS,United States
@@ -5082,6 +6153,7 @@ UNS,Unsped Paket Servisi,UNSPED,Turkey
 UNT,Servicios Aéreos Universitarios,UNIVERSITARIO,Mexico
 UNU,Unifly Servizi Aerei,UNIEURO,Italy
 UNY,Lund University School of Aviation,UNIVERSITY,Sweden
+UPA,Air Foyle,,United Kingdom
 UPL,Ukrainian Pilot School,PILOT SCHOOL,Ukraine
 UPS,United Parcel Service,UPS,United States
 URA,Aircompany Rosavia,ROSAVIA,Ukraine
@@ -5089,9 +6161,12 @@ URF,Surf Air,SURF AIR,United States
 URG,Air Urga,URGA,Ukraine
 URJ,Star Air,STARAV,Pakistan
 URN,Turan Air,TURAN,Azerbaijan
+URO,European Cargo Limited,EURO,United Kingdom
 URP,ARP 410 Airlines,AIR-ARP,Ukraine
+URR,Aurora Airlines,,Slovenia
 URV,Uraiavia,URAI,Russia
 URY,Century Aviation,CENTURY AVIA,Mexico
+USA,US Airways,,United States
 USB,Tusheti,TUSHETI,Georgia
 USC,AirNet Express,STAR CHECK,United States
 USF,USAfrica Airways,AFRICA EXPRESS,United States
@@ -5103,6 +6178,7 @@ UST,Austro Aéreo,AUSTRO AEREO,Ecuador
 USW,Special Aviation Works,AKSAR,Uzbekistan
 USX,US Express,AIR EXPRESS,United States
 UTA,UTair Aviation,UTAIR,Russia
+UTG,UTAGE,,Equatorial Guinea
 UTM,TAPC Aviatrans Aircompany,AVIATAPS,Uzbekistan
 UTN,UTair-Ukraine,UT Ukraine,Ukraine
 UTR,Utair South Africa,AIRUT,South Africa
@@ -5115,11 +6191,17 @@ UVA,Universal Airways,UNIVERSAL,United States
 UVG,Universal Airlines,GUYANA JET,Guyana
 UVM,Uvavemex,UVAVEMEX,Mexico
 UVN,United Aviation,UNITED AVIATION,Kuwait
+UVS,Air Universal,,Sierra Leone
 UVT,Auvia Air,AUVIA,Indonesia
+UWD,Skyward Aviation,UPWARD,United States
+UWJ,Ukrainian Wings,UKRAINIAN WINGS,Ukraine
+UWW,LSM International ,,Russia
 UYA,Yute Air Alaska,,United States
+UYC,Cameroon Airlines,,Cameroon
 UZA,Constanta Airline,CONSTANTA,Ukraine
 UZB,Uzbekistan Airways,UZBEK,Uzbekistan
 UZS,Samarkand Airways,SOGDIANA,Uzbekistan
+VA3,3 Valleys Airlines,,France
 VAA,Van Air Europe,EUROVAN,Czech Republic
 VAB,Airtrans Ltd,,Russia
 VAC,Vacationair,VACATIONAIR,Canada
@@ -5127,31 +6209,42 @@ VAD,Aero Taxi Los Valles,VALLES,Spain
 VAE,Air Evans,AIR-EVANS,Spain
 VAG,Vietravel Airlines,VIETRAVEL AIR,Vietnam
 VAI,Avalair,AIR AVALAIR,Serbia
+VAJ,Avcon Jet SRL,TRUBADIX,SM
 VAL,Voyageur Airways,VOYAGEUR,Canada
 VAM,Ameravia,AMERAVIA,Uruguay
 VAN,Caravan Air,CAMEL,Mauritania
 VAP,Phuket Air,PHUKET AIR,Thailand
-VAR,Veca Airlines,VECA,El Salvador
+VAR,United Aviate Academy,VARNEY,United States
 VAS,ATRAN Cargo Airlines,ATRAN,Russian Federation
 VAT,Visionair,VISIONAIR,Ireland
+VAU,V Australia Airlines,,Australia
+VAV,Angkor Air,,Cambodia
+VAW,Fly2Sky o.o.d.,SOFIA JET,Bulgaria
+VAX,V Air,,Taiwan
 VAZ,Airlines 400,REMONT AIR,Russia
 VBA,V Bird Airlines Netherlands,VEEBEE,Netherlands
+VBB,ALK Airlines,AIR LUBO,Bulgaria
 VBC,AVB-2004 Ltd,AIR VICTOR,Bulgaria
 VBD,V-Berd-Avia,VEEBIRD-AVIA,Armenia
 VBG,North-West Air Transport Company - Vyborg,VYBORG AIR,Russia
+VBI,Virgin Blue,,Australia
 VBW,Air Burkina,BURKINA,Burkina Faso
+VC9,Volotea Costa Rica,,Costa Rica
 VCA,VICA - Viacao Charter Aéreos,VICA,Brazil
 VCB,Real Aero Club de Vizcaya,,Spain
 VCG,Catreus,THUNDERCAT,United Kingdom
 VCH,Consorcio Helitec,CONSORCIO HELITEC,Venezuela
 VCI,CI-Tours,CI-TOURS,Ivory Coast
+VCJ,Avcon Jet Malta Ltd,OBELIX,Malta
 VCM,Volare Air Charter Company,CARMEN,United States
 VCN,Execujet Charter,AVCON,Switzerland
 VCR,Cruiser Linhas Aéreas,VOE CRUISER,Brazil
 VCT,Viscount Air Service,VISCOUNT AIR,United States
 VCV,Conviasa,CONVIASA,Venezuela
 VCX,Ocean Airlines,OCEANCARGO,Italy
+VCY,One Caribbean,VINCY,Saint Vincent and the Grenadines
 VDA,Volga-Dnepr Airlines,VOLGA,Russia
+VDC,Excelair,PRIVIUM,Spain
 VDO,Servicios Aéreos Avandaro,AVANDARO,Mexico
 VDR,Air Vardar,VARDAR,Macedonia
 VEA,Vega Airlines,VEGA AIRLINES,Bulgaria
@@ -5163,12 +6256,16 @@ VEJ,Aero Ejecutivos,VENEJECUTIV,Venezuela
 VEN,Transaven,TRANSAVEN AIRLINE,Venezuela
 VER,Almaver,ALMAVER,Mexico
 VES,Vieques Air Link,VIEQUES,United States
+VET,Venture Aviation Group,POINSETT AIR,United States
 VEX,Virgin Express,VIRGIN EXPRESS,Belgium
 VFC,Vietnam Air Services Company (VASCO),VASCO AIR,Vietnam
 VFT,VZ Flights,ZETA FLIGHTS,Mexico
+VGA,Air Vegas,,United States
+VGB,Beijing Tianxinai General Aviation,HONG XIANG,China
 VGC,Vanguardia en Aviación en Colima,VANGUARDIA COLIMA,Mexico
 VGD,Vanguard Airlines,VANGUARD AIR,United States
 VGF,Aerovista Gulf Express,VISTA GULF,United Arab Emirates
+VGJ,Vigo Jet,,Mexico
 VGN,Virgin Nigeria Airways,VIRGIN NIGERIA,Nigeria
 VGO,Sabaidee Airways,VIRGO,Thailand
 VGS,Stichting Vliegschool 16Hoven,SMART,Netherlands
@@ -5176,8 +6273,11 @@ VGV,Vologda State Air Enterprise,VOLOGDA AIR,Russia
 VHA,VH-Air Industrie,AIR V-H,Angola
 VHM,VHM Schul-und-Charterflug,EARLY BIRD,Germany
 VHT,Corporate Flight International,VEGAS HEAT,United States
+VI4,Vuola Italia,,Italy
+VIA,VIA Líneas Aéreas,,Argentina
 VIB,Vibroair Flugservice,VITUS,Germany
 VIC,VIP Servicios Aéreos Ejecutivos,VIP-EJECUTIVO,Mexico
+VID,Aviaprad,,Russia
 VIE,VIP Empresarial,VIP EMPRESARIAL,Mexico
 VIF,VIF Luftahrt,VIENNA FLIGHT,Austria
 VIG,Vega Aviation,VEGA AVIATION,Sudan
@@ -5188,6 +6288,8 @@ VIM,Air VIA,CRYSTAL,Bulgaria
 VIN,Vinair Aeroserviços,VINAIR,Portugal
 VIP,Tag Aviation UK,SOVEREIGN,United Kingdom
 VIR,Virgin Atlantic,VIRGIN,United Kingdom
+VIS,Vision Air International,,Pakistan
+VIT,Aviastar Mandiri,AVIASTAR,Indonesia
 VIV,Aeroenlaces Nacionales,AEROENLACES,Mexico
 VIZ,Aerovis Airlines,AEROVIZ,Ukraine
 VJA,ValuJet Airlines,CRITTER,United States
@@ -5195,22 +6297,29 @@ VJC,Vietjet Air,VIETJET,Vietnam
 VJE,AvJet Routing,,United Arab Emirates
 VJM,Viajes Ejecutivos Mexicanos,VIAJES MEXICANOS,Mexico
 VJT,Vistajet,VISTA,Canada
+VKA,Vulkan Air,VULKAN AIR,Ukraine
+VKG,Mytravel Airways,,Denmark
+VKH,Viking Hellas,,Greece
+VKJ,VickJet,,France
 VLA,Valan International Cargo Charter,NALAU,South Africa
 VLB,Air Volta,VOLTA,Bulgaria
 VLE,C.A.I. Second,VOLA,Italy
 VLF,DFS UK Limited,VOLANTE,United Kingdom
 VLG,Vueling Airlines,VUELING,Spain
+VLI,Avolar Aerolineas,,Mexico
 VLJ,Valljet,VALLJET,Canada
 VLK,Vladivostok Air,VLADAIR,Russia
 VLL,RAF Valley SAR Training Unit,,United Kingdom
 VLM,VLM Airlines,RUBENS,Belgium
 VLN,Valan Limited,VALAN,Moldova
+VLO,Varig Log,,Brazil
 VLR,Aerolíneas Villaverde,VILLAVERDE,Mexico
 VLS,Aero Virel,VIREL,Mexico
 VLT,Vertical-T Air Company,VERTICAL,Russia
 VLU,Valuair,VALUAIR,Singapore
 VLV,Avialift Vladivostok,VLADLIFT,Russia
 VLX,Biz Jet Charter,AVOLAR,United States
+VLZ,Volare Aviation,VOLARE,United Kingdom
 VMA,Vero Monmouth Airlines,VERO MONMOUTH,United States
 VME,Aviación Comercial de América,AVIAMERICA,Mexico
 VMM,Grupo Vuelos Mediterraneo,VUELOS MED,Spain
@@ -5219,29 +6328,38 @@ VMR,Aero Vilamoura,AERO VILAMOURA,Portugal
 VMS,His Majesty King Maha Vajiralongkorn,VICTOR MIKE[27],Thailand
 VMX,Aeroventas de Mexico,VENTA,Mexico
 VNA,Empresa Aviación Interamericana,EBBA,Uruguay
+VNC,Intervuelos Nacionales SA de CV,,Mexico
 VNE,Empresa Venezolana,VENEZOLANA,Venezuela
 VNG,Aero Servicios Vanguardia,VANGUARDIA,Mexico
 VNK,Vipport Joint Stock Company,,Russia
 VNL,Vanilla Air,VANILLA,Japan
+VNP,Virgin Pacific,,Fiji
 VNT,Avient Air Zambia,AVIENT,Zambia
 VNX,Fly Advance,VANCE,United States
 VNZ,Tbilaviamsheni,TBILAVIA,Georgia
 VOA,Viaggio Air,VIAGGIO,Bulgaria
+VOC,Volaris Costa Rica,ROSTA RICAN,Costa Rica
 VOE,Volotea,VOLOTEA,Spain
 VOG,Voyager Airlines,VOYAGER AIR,Bangladesh
 VOI,Volaris,VOLARIS,Mexico
 VOL,Blue Chip Jet,BLUE SPEED,Sweden
+VOO,Volotea,,Spain
 VOR,Flight Calibration Services Ltd.,FLIGHT CAL,United Kingdom
 VOS,Rovos Air,ROVOS,South Africa
 VOZ,Virgin Australia,VELOCITY,Australia
 VPA,DanubeWings,VIP TAXI,Slovakia
 VPB,Veteran Air,VETERAN,Ukraine
+VPC,Panaviatic,SOLAR,Estonia
+VPE,Viva Air Peru,VIVA PERU,Peru
+VPP,Vintage Props and Jets,,United States
 VPV,VIP-Avia,VIP AVIA,Georgia
+VQI,Flyme (VP),,Maldives
 VRA,Vertair,VERITAIR,United Kingdom
 VRB,Silverback Cargo Freighters,SILVERBACK,Rwanda
 VRC,Taxi de Veracruz,VERACRUZ,Mexico
 VRD,Virgin America,REDWOOD,United States
 VRE,Air Côte d'Ivoire,COTE DIVORIE,Ivory Coast
+VRH,Varesh Airlines,SKY VICTOR,IR
 VRI,Aerotaxi Villa Rica,VILLARICA,Mexico
 VRL,Voar Lda,VOAR LINHAS,Angola
 VRN,Varig,VARIG,Brazil
@@ -5254,10 +6372,12 @@ VSC,Aeronautic de Los Pirineos,,Spain
 VSG,AirClass Airways,VISIG,Spain
 VSN,Vision Airways Corporation,VISION,Canada
 VSO,Voronezh Aircraft Manufacturing Society,VASO,Russia
+VSP,VASP,,Brazil
 VSR,Aviostart AS,AVIOSTART,Bulgaria
 VSS,Virign Islands Seaplane Shuttle,WATERBIRD,United States
 VSV,Scat Air,VLASTA,Kazakhstan
 VTA,Air Tahiti,AIR TAHITI,French Polynesia
+VTB,Jet Strean Charter,SUXAIR,Hungary
 VTC,Vuelos Especializados Tollocan,VUELOS TOLLOCAN,Mexico
 VTE,Contour Airlines,VOLUNTEER,United States
 VTG,Aviação Transportes Aéreos e Cargas,ATACARGO,Angola
@@ -5268,23 +6388,32 @@ VTL,Victor Tagle Larrain,VITALA,Chile
 VTM,Aeronaves TSM,AERONAVES TSM,Mexico
 VTS,Everts Air Alaska/Everts Air Cargo,EVERTS,United States
 VTT,Avia Trans Air Transport,VIATRANSPORT,Sudan
+VTU,Turpial Airlines,TURPIAL,VE
 VTV,Vointeh,VOINTEH,Bulgaria
 VTX,Verataxis,VERATAXIS,Mexico
 VTY,Air Midwest (Nigeria),VICTORY,Nigeria
 VUE,AD Aviation,FLIGHTVUE,United Kingdom
 VUL,Elios,ELIOS,Italy
+VUN,Air Ivoire,,Ivory Coast
 VUO,Aerovuelox,AEROVUELOX,Mexico
+VUR,Vuelos Internos Privados VIP,,Ecuador
 VUS,Vuela Bus,VUELA BUS,Mexico
+VVA,Aviast Air,,Russia
 VVC,Viva Air Colombia,Viva Air Colombia,Colombia
 VVF,Dunyaya Bakis Hava Tasimaciligi,WORLDFOCUS,Turkey
 VVG,Aerovilla,AEROVILLA,Colombia
 VVM,Viva Macau,JACKPOT,Macao
+VVN,88,,Cyprus
 VVV,Valair Aviação Lda,VALAIRJET,Portugal
+VWA,Virginwings,,Germany
 VXG,Avirex,AVIREX-GABON,Gabon
 VXN,Sunset Aviation,VIXEN,United States
 VXP,Mali Air Express,AVION EXPRESS,Mali
+VXS,Voluxis,VOLUXIS,United Kingdom
 VXX,Aviaexpress Aircompany,EXPRESSAVIA,Ukraine
+VYE,First Jet,JET SOLUTIONS,Mexico
 VYT,RAF Valley Flying Training Unit,ANGLESEY,United Kingdom
+VZA,ViznAir,,United States
 VZL,Vzlyet,VZLYET,Russia
 VZR,Aviazur,IAZUR,France
 WAA,Westair Aviation,WESTAIR WINGS,Namibia
@@ -5295,6 +6424,7 @@ WAE,Western Air Express,WESTERN EXPRESS,United States
 WAF,Flamenco Airways,FLAMENCO,United States
 WAG,Wisconsin Air National Guard,,United States
 WAJ,AirAsia Japan,WING ASIA,Japan
+WAK,Wings of Alaska,,United States
 WAL,Western Arctic Air,WESTERN ARCTIC,Canada
 WAM,Air Taxi & Cargo,TAXI CARGO,Sudan
 WAN,Wataniya Airways,WATANIYA,Kuwait
@@ -5302,9 +6432,11 @@ WAP,Arrow Panama,ARROW PANAMA,Panama
 WAR,NZ Warbirds Association,WARBIRDS,New Zealand
 WAS,Air-Watania,,Iraq
 WAT,Wings Air Transport,,Sudan
+WAU,Wizz Air Ukraine,,Ukraine
 WAV,Warbelow's Air Ventures,WARBELOW,United States
 WAW,Wings Airways,WING SHUTTLE,United States
 WAY,Airways,GARONNE,France
+WAZ,Wizz Air,WIZZ SKY,United Arab Emirates
 WBA,Finncomm Airlines,WESTBIRD,Finland
 WBR,Multi-Aero,WEBER,United States
 WCA,West Coast Airways,WEST-LEONE,Sierra Leone
@@ -5317,18 +6449,22 @@ WCR,West Caribbean Costa Rica,WEST CARIBBEAN,Costa Rica
 WCW,West Caribbean Airways,WEST,Colombia
 WCY,Viking Express,TITAN AIR,United States
 WDA,Wimbi Dira Airways,WIMBI DIRA,Democratic Republic of Congo
-WDG,Ministry of Agriculture, Fisheries and Food,WATCHDOG,United Kingdom
+WDE,Pallas Aviation,SANDSTONE,United States
+WDG,Ministry of Agriculture Fisheries and Food,WATCHDOG,United Kingdom
 WDK,Oxford Air Services,WOODSTOCK,United Kingdom
 WDL,WDL Aviation,WDL,Germany
 WDR,Air Net Private Charter,WIND RIDER,United States
 WDS,Four Winds Aviation,WINDS,United States
 WDY,Chicago Jet Group,WINDY CITY,United States
+WE1,World Experience Airline,,Canada
 WEA,White Eagle Aviation,WHITE EAGLE,Poland
 WEB,WebJet Linhas Aéreas,WEB-BRASIL,Brazil
 WEC,Universal Airlines,AIRGO,United States
-WEL,Veles, Ukrainian Aviation Company,VELES,Ukraine
+WEL,Veles Ukrainian Aviation Company,VELES,Ukraine
 WEN,WestJet Encore,ENCORE,Canada
+WER,AeroWorld,,Russia
 WES,Rainbow International Airlines,WEST INDIAN,United States
+WET,Flywet,,Mexico
 WEV,Victoria International Airways,VICTORIA UGANDA,Uganda
 WEW,West Wind Aviation,WESTWIND,Canada
 WEX,Wings Express,WINGS EXPRESS,United States
@@ -5336,7 +6472,9 @@ WFC,Swift Copters,SWIFTCOPTERS,Switzerland
 WFD,BAE Systems,AVRO,United Kingdom
 WFO,Wilbur's Flight Operations,WILBURS,United States
 WFT,Aircharters Worldwide,WORLD FLIGHT,United States
+WFX,Westfalia Express VA,,Germany
 WGA,Vega Air Company,WEGA FRANKO,Ukraine
+WGC,Worldways,,Canada
 WGN,Western Global Airlines,WESTERN GLOBAL,United States
 WGP,Williams Grand Prix Engineering,GRAND PRIX,United Kingdom
 WGS,Airwings oy,AIRWINGS,Finland
@@ -5357,11 +6495,14 @@ WIT,RAF Wittering,STRIKER,United Kingdom
 WIW,V-avia Airline,VEE-AVIA,Ukraine
 WIZ,Micromatter Technology Solutions,WIZARD,United Kingdom
 WJA,WestJet,WESTJET,Canada
+WJM,Windsor Jet Management,WINDSOR JET,United States
+WJT,WiJet,WIJET,France
 WKH,Kharkov Aircraft Manufacturing Company,WEST-KHARKOV,Ukraine
-WKT,Whiteknight UK MOD,,United Kingdom
+WKT,DEA Aviation (Specialised Airborne Ops),WHITE KNIGHT,United Kingdom
 WLA,Airwaves Airlink,AIRLIMITED,Zambia
 WLB,Wings of Lebanon Aviation,WING LEBANON,Lebanon
 WLC,Welcome Air,WELCOMEAIR,Austria
+WLD,Wilderness Air,WILDERNESS,South Africa
 WLG,Air Volga,GOUMRAK,Russia
 WLK,Skyrover CC,SKYWATCH,South Africa
 WLR,Air Walser,AIRWALSER,Italy
@@ -5369,7 +6510,10 @@ WLS,Air Wales Virtual,WALES,United Kingdom
 WLT,Aviation Partners,WINGLET,United States
 WLV,Aviation North,WOLVERINE,United States
 WLX,West Air Luxembourg,WEST LUX,Luxembourg
+WMA,Watermakers Air,WATERMAKERS,United States
 WML,Chantilly Air,MARLIN,United States
+WMN,Trident Aircraft,WATERMAN,United States
+WMU,W.M. Uni. College of Aviation,SKYBRONCO,United States
 WNA,Winair,WINAIR,United States
 WNR,Wondair on Demand Aviation,WONDAIR,Spain
 WOA,World Airways,WORLD,United States
@@ -5382,8 +6526,10 @@ WPK,Air-Lift Associates,WOLFPACK,United States
 WPR,Auckland Regional Rescue Helicopter Trust,WESTPAC RESCUE,New Zealand
 WPT,Wapiti Aviation,WAPITI,Canada
 WRA,White River Air Services,,Canada
+WRC,Wind Rose Aviation,,Ukraine
 WRF,Wright Air Service,WRIGHT FLYER,United States
 WRR,WRA Inc,WRAP AIR,United States
+WRT,Wright Air Lines,,United States
 WSA,Westgates Airlines,WESTATES,United States
 WSC,Westair Cargo Airlines,WESTCAR,Côte d'Ivoire
 WSF,West African Airlines,,Benin
@@ -5392,17 +6538,21 @@ WSI,Wind Spirit Air,WIND SPIRIT,United States
 WSL,Westflight Aviation,WEST LINE,United Kingdom
 WSM,Wisman Aviation,WISMAN,United States
 WSN,Advanced Air,WINGSPAN,United States
+WSS,World Scale Airlines,,United States
 WST,Western Air,WESTERN BAHAMAS,Bahamas
 WSW,Swoop,SWOOP,Canada
 WTA,Africa West,WEST TOGO,Togo
 WTC,Weasua Air Transport Company,WATCO,Liberia
 WTF,West African Air Transport,WESTAF AIRTRANS,Senegal
+WTJ,Whitejets,,Brazil
 WTN,BAE Systems,TARNISH,United Kingdom
 WTP,Westpoint Air,WESTPOINT,Canada
 WTV,Western Aviators,WESTAVIA,United States
+WUE,Adolf Wurth GmbH,FASTY,Germany
 WUK,Wizz Air UK,WIZZ GO,United Kingdom
 WVA,Hand D Aviation,WABASH VALLEY,United States
 WVL,Wizz Air Bulgaria,WIZZBUL,Bulgaria
+WVZ,Winair,,HR
 WWD,Westward Airways,WESTWARD,United States
 WWG,Aereo WWG,AERO-W,Mexico
 WWI,Worldwide Jet Charter,WORLDWIDE,United States
@@ -5414,6 +6564,7 @@ WYG,Wyoming Airlines,WYOMING,United States
 WYT,2 Sqn No 1 Elementary Flying Training School,WYTON,United Kingdom
 WZP,Zip,ZIPPER,Canada
 WZZ,Wizz Air,WIZZAIR,Hungary
+X9F,FRA Air,,Germany
 XAA,Aeronautical Radio Inc,,United States
 XAB,Xabre Aerolineas,AERO XABRE,Mexico
 XAC,Air Charter World,,United States
@@ -5423,6 +6574,7 @@ XAF,Executive Air Fleet,,United States
 XAH,Executive Aircraft Services,,United Kingdom
 XAK,Airkenya,SUNEXPRESS,Kenya
 XAM,AMR Services Corporation,ALLIANCE,United States
+XAN,Southjet cargo,,United States
 XAO,Airline Operations Services,,United States
 XAP,Direct Air trading as Midway Connection,MID-TOWN,United States
 XAR,XpressAir,XPRESS,Indonesia
@@ -5432,9 +6584,11 @@ XAU,Aerolink Uganda,PEARL,Uganda
 XAV,Aviaprom Enterprises,AVIAPROM,Russia
 XAX,AirAsia X,XANADU,Malaysia
 XBG,City of Bangor,,United States
+XBM,CBM America,,United States
 XBO,Baseops International,,United States
 XCA,Colt Transportes Aereos,COLT,Brazil
 XCC,Ecoturistica de Xcalak,XCALAK,Mexico
+XCH,Jet Exchange,EXCHANGE,United Kingdom
 XCL,Contel ASC,,United States
 XCO,Compuflight Operations Service,,United States
 XCS,Compuserve Incorporated,,United States
@@ -5447,14 +6601,19 @@ XDT,Date Transformation Corp,,United States
 XDY,Dynair Services,,United States
 XEC,Air Executive Charter,,Germany
 XEL,Excel Charter,HELI EXCEL,United Kingdom
+XEN,ZEN Flight,ZEN JET,United States
 XER,Xerox Corporation,XEROX,United States
 XFA,FlyAsianXpress,FAX AIR,Malaysia
+XFL,Executive Fliteways Inc,EX-FLIGHT,United States
 XFS,American Flight Service Systems,,United States
 XFX,Airways Corporation of New Zealand,AIRCORP,New Zealand
 XGA,General Aviation Terminal,,Canada
 XGG,IMP Group Aviation Services,,Canada
+XGN,NexGen Flight Solutions,NEXGEN,United States
+XGO,AirGO Flugservice GmbH & Co KG,PASTIS,Germany
 XGS,Global System,,United States
 XGW,Global Weather Dynamics,,United States
+XIA,Irving Oil,,Canada
 XJA,Assistance Aeroportuaire de L'Aeroport de Paris,,France
 XJC,XJC Limited,EXCLUSIVE JET,United Kingdom
 XJE,X-Jet,,Austria
@@ -5463,9 +6622,14 @@ XKA,Kavouras Inc,,United States
 XKX,ASECNA,,France
 XLA,Excel Airways,EXPO,United Kingdom
 XLB,Aircraft Performance Group,,United States
+XLD,Jeppesen Data Plan,,United States
+XLF,XL Airways France,STARWAY,FR
+XLJ,Xcel Jet Management,XCEL JET,United States
 XLG,Lockheed Air Terminal,,United States
 XLK,Safarilink Aviation,SAFARILINK,Kenya
 XLL,Air Excel,TINGA-TINGA,Tanzania
+XLR,Texel Air,TEXEL,Bahrain
+XLS,ExcelAire LLC,EXCELAIRE,United States
 XLT,Empressa Brasileira de Infra-Estrutura Aeroportuaria-Infraero,INFRAERO,Brazil
 XMA,Martin Aviation Services,,United States
 XME,Australian air Express,AUS-CARGO,Australia
@@ -5487,6 +6651,7 @@ XPL,Express Line Aircompany,EXPRESSLINE,United States
 XPN,Aero Express,,Niger
 XPR,Air-Rep,,United States
 XPS,XP International,XP PARCEL,Netherlands
+XPT,XPTO,,Portugal
 XPX,Phoenix Flight Operations,,United States
 XRA,Intensive Air,INTENSIVE,South Africa
 XRC,Express Air Cargo,,Tunisia
@@ -5507,14 +6672,20 @@ XXV,AASANA,,Bolivia
 XXX,ASL (Air Service Liege),,Belgium
 XYZ,Island Air Express,RAINBIRD,United States
 YAK,Yakolev,YAK AVIA,Russia
+YAP,OLT Express Poland,WHITEKEKO,Poland
 YBE,Stewart Aviation Services,YELLOW BIRD,United States
+YCC,Ciel Canadien,,Canada
+YCP,Canadian National Airways,,Canada
 YEL,Summit Aviation,YELLOWSTONE,United States
+YEP,YES Airways,,Poland
 YFS,Young Flying Service,YOUNG AIR,United States
 YOG,Central Aviation,YOGAN AIR,United States
 YRG,Yak Air,YAKAIR GEORGIA,Georgia
 YWZ,West Coast Air,COAST AIR,Canada
-YYY,ICAO,,
+YYY,ICAO,,Worldwide
 YZR,Yangtze River Express,YANGTZE RIVER,China
+YZZ,LSM AIRLINES,,Russia
+Z9H,All Argentina Express,,Argentina
 ZAI,Zaire Aero Service,ZASAIR,Democratic Republic of Congo
 ZAK,Airlink Zambia,,Zambia
 ZAN,Zantop International Airlines,ZANTOP,United States
@@ -5523,9 +6694,13 @@ ZAS,ZAS Airlines of Egypt,ZAS AIRLINES,Egypt
 ZAV,Zetavia,ZETAVIA,Ukraine
 ZAW,Zoom Airways,ZED AIR,Bangladesh
 ZBA,Boskovic Air Charters Limited,BOSKY,Kenya
+ZCS,Southjet connect,,United States
 ZMA,Zambezi Airlines,ZAMBEZI WINGS,Zambia
+ZNA,Zenith International Airline,,Thailand
+ZTF,Mongolian International Air Lines,,Mongolia
+ZTT,ZABAIKAL AIRLINES,,Russia
 ZXP,Netherlands Police,,Netherlands
+ZXY,Japan Regio,,Japan
+ZYZ,Caribbean Wings,,Turks and Caicos Islands
 ZZM,Agence Nationale des Aerodromes et de la Meteorologie,,Ivory Coast
-ISC,Isles of Scilly Skybus,,United Kingdom
-MMF,Netherlands Air Force,,Netherlands
-OPM,Fireblade Aviation,,South Africa
+ZZZ,Zabaykalskii Airlines,,Russia

--- a/rootfs/usr/share/planefence/stage/planefence.config
+++ b/rootfs/usr/share/planefence/stage/planefence.config
@@ -387,3 +387,12 @@ MASTODON_ACCESS_TOKEN=
 PF_MASTODON_VISIBILITY=unlisted
 PA_MASTODON_VISIBILITY=unlisted
 #
+#
+# ---------------------------------------------------------------------
+# Plane-Alert Exclusions. Entries here will be excluded from Plane-Alert notifications on Mastodon and Discord, 
+# and won't be recorded in the Plane-Alert web UI. Accepted values are ICAO type codes (e.g. TEX2 for T-6 Texans),
+# ADS-B hex codes (e.g. AE06D9), or any string found in the plane's database entry (e.g. N24HD, 92-03327, UC-12W,
+# Kid Rock, ambulance, et cetera). Multiple exclusions should be separated by commas. Entries are not case sensitive.
+# After making additions or changes, examine the container logs to verify it's doing what you intended it to!
+# Note that URLs and image links are not searched. Leave this blank to disable.
+PA_EXCLUSIONS=


### PR DESCRIPTION
Add functionality to plane-alert to allow users to exclude specified planes. Below snip from updated README

#### Plane-Alert Exclusions

In some circumstances you may wish to blacklist certain planes, or types of planes, from appearing in Plane-Alert and its Mastodon and Discord posts. This may be desireable if, for example, you're located near a military flight training base, where you could be flooded with dozens of notifications about T-6 Texan training aircraft every day, which could drown out more interesting planes. To that end, excluding planes can be accomplished using the `PA_EXCLUSIONS=` parameter in `/opt/adsb/planefence/config/planefence.config`. Currently, you may exclude whole ICAO Types (such as `TEX2` to remove all T-6 Texans), specific ICAO hexes (e.g. `AE1ECB`), specific registrations and tail codes (e.g. `N24HD` or `92-03327`), or any freeform string (e.g. `UC-12`, `Mayweather`, `Kid Rock`). Multiple exclusions should be separated by commas. Exclusions are case insensitive and spaces **must** be escaped with a slash `\`. An example:
```yml
PA_EXCLUSIONS=tex2,AE06D9,ae27fe,Floyd\ Mayweather,UC-12W
```
This would exclude *all* T-6 Texans, the planes with ICAO hexes `AE06D9` (a Marine Corps UC-12F Huron) and `AE27FE` (a Coast Guard MH-60T), any planes with "Floyd Mayweather" anywhere in the database entry, and any planes with "UC-12W" anywhere in the database entry. URLs and image links are intentionally not searched.

*Please note:* this is a **powerful feature** which may produce unintended consequences. You should verify that it's working correctly by examining the container logs after making changes to `planefence.config`. You should see, e.g.:
```
tex2 appears to be an ICAO type and is valid, entries excluded: 479
AE06D9 appears to be an ICAO hex and is valid, entries excluded: 1
ae27fe appears to be an ICAO hex and is valid, entries excluded: 1
Floyd Mayweather appears to be a freeform search pattern, entries excluded: 1
UC-12W appears to be a freeform search pattern, entries excluded: 8
490 entries excluded.
```