### PR TITLE
Set retained attribute to all MQTT messages.

### DIFF
--- a/rootfs/scripts/mqtt.py
+++ b/rootfs/scripts/mqtt.py
@@ -35,7 +35,7 @@ def publish_message(broker, port, topic, qos, message, client_id, username=None,
         # Connect to the MQTT broker
         client.connect(broker, port)
         # Publish the message
-        client.publish(topic, payload=message, qos=qos)
+        client.publish(topic, payload=message, qos=qos, retain=True)
         print(f"Message '{message}' published to topic '{topic}' with QoS {qos}.")
         # Disconnect from the broker
         client.disconnect()


### PR DESCRIPTION
Sets the retained flag to true for all MQTT messages. This ensures that subscribers 
get the last known good value for a topic, allowing them to get the last value 
even if they were disconnected at the moment of publication.

Retaining only keeps the most recent message, so broker load is trivial.

