### PR TITLE
Update links to planefence repo.

### DIFF
--- a/rootfs/usr/lib/python3/dist-packages/pflib/__init__.py
+++ b/rootfs/usr/lib/python3/dist-packages/pflib/__init__.py
@@ -3,7 +3,7 @@
 # Copyright 2022-2025 Ramon F. Kolb and Justin DiPierro - licensed under the terms and conditions
 # of GPLv3. The terms and conditions of this license are included with the Github
 # distribution of this package, and are also available here:
-# https://github.com/sdr-enthusiasts/planefence/
+# https://github.com/sdr-enthusiasts/docker-planefence/
 #
 # The package contains parts of, and modifications or derivatives to the following:
 # Dump1090.Socket30003 by Ted Sluis: https://github.com/tedsluis/dump1090.socket30003

--- a/rootfs/usr/share/plane-alert/html/index.html
+++ b/rootfs/usr/share/plane-alert/html/index.html
@@ -9,7 +9,7 @@
 # Copyright 2021-2025 Ramon F. Kolb - licensed under the terms and conditions
 # of GPLv3. The terms and conditions of this license are included with the Github
 # distribution of this package, and are also available here:
-# https://github.com/sdr-enthusiasts/plane-alert/
+# https://github.com/sdr-enthusiasts/docker-planefence/
 #
 # The package contains parts of, links to, and modifications or derivatives to the following:
 # Dump1090.Socket30003 by Ted Sluis: https://github.com/tedsluis/dump1090.socket30003

--- a/rootfs/usr/share/plane-alert/plane-alert.conf
+++ b/rootfs/usr/share/plane-alert/plane-alert.conf
@@ -3,7 +3,7 @@
 # Copyright 2021-2025 Ramon F. Kolb - licensed under the terms and conditions
 # of GPLv3. The terms and conditions of this license are included with the Github
 # distribution of this package, and are also available here:
-# https://github.com/sdr-enthusiasts/plane-alert/
+# https://github.com/sdr-enthusiasts/docker-planefence/
 #
 # The package contains parts of, and modifications or derivatives to the following:
 # Dump1090.Socket30003 by Ted Sluis: https://github.com/tedsluis/dump1090.socket30003

--- a/rootfs/usr/share/plane-alert/plane-alert.header.html
+++ b/rootfs/usr/share/plane-alert/plane-alert.header.html
@@ -9,7 +9,7 @@
 # Copyright 2021-2025 Ramon F. Kolb (kx1t) - licensed under the terms and conditions
 # of GPLv3. The terms and conditions of this license are included with the Github
 # distribution of this package, and are also available here:
-# https://github.com/sdr-enthusiasts/planefence/
+# https://github.com/sdr-enthusiasts/docker-planefence/
 #
 # The package contains parts of, links to, and modifications or derivatives to the following:
 # Dump1090.Socket30003 by Ted Sluis: https://github.com/tedsluis/dump1090.socket30003

--- a/rootfs/usr/share/plane-alert/plane-alert.sh
+++ b/rootfs/usr/share/plane-alert/plane-alert.sh
@@ -8,7 +8,7 @@
 # Copyright 2021-2025 Ramon F. Kolb - licensed under the terms and conditions
 # of GPLv3. The terms and conditions of this license are included with the Github
 # distribution of this package, and are also available here:
-# https://github.com/sdr-enthusiasts/planefence/
+# https://github.com/sdr-enthusiasts/docker-planefence/
 #
 # The package contains parts of, and modifications or derivatives to the following:
 # Dump1090.Socket30003 by Ted Sluis: https://github.com/tedsluis/dump1090.socket30003

--- a/rootfs/usr/share/plane-alert/send-discord-alert.py
+++ b/rootfs/usr/share/plane-alert/send-discord-alert.py
@@ -9,7 +9,7 @@
 # Licensed under the terms and conditions
 # of GPLv3. The terms and conditions of this license are included with the Github
 # distribution of this package, and are also available here:
-# https://github.com/sdr-enthusiasts/planefence/
+# https://github.com/sdr-enthusiasts/docker-planefence/
 #
 # The package contains parts of, and modifications or derivatives to the following:
 # Dump1090.Socket30003 by Ted Sluis: https://github.com/tedsluis/dump1090.socket30003

--- a/rootfs/usr/share/planefence/noise2fence.sh
+++ b/rootfs/usr/share/planefence/noise2fence.sh
@@ -5,7 +5,7 @@
 # Copyright 2020-2025 Ramon F. Kolb - licensed under the terms and conditions
 # of GPLv3. The terms and conditions of this license are included with the Github
 # distribution of this package, and are also available here:
-# https://github.com/sdr-enthusiasts/planefence/
+# https://github.com/sdr-enthusiasts/docker-planefence/
 #
 # The package contains parts of, and modifications or derivatives to the following:
 # Dump1090.Socket30003 by Ted Sluis: https://github.com/tedsluis/dump1090.socket30003

--- a/rootfs/usr/share/planefence/planefence.sh
+++ b/rootfs/usr/share/planefence/planefence.sh
@@ -9,7 +9,7 @@
 # Copyright 2020-2025 Ramon F. Kolb (kx1t) - licensed under the terms and conditions
 # of GPLv3. The terms and conditions of this license are included with the Github
 # distribution of this package, and are also available here:
-# https://github.com/sdr-enthusiasts/planefence/
+# https://github.com/sdr-enthusiasts/docker-planefence/
 #
 # The package contains parts of, and modifications or derivatives to the following:
 # Dump1090.Socket30003 by Ted Sluis: https://github.com/tedsluis/dump1090.socket30003

--- a/rootfs/usr/share/planefence/planeheat.sh
+++ b/rootfs/usr/share/planefence/planeheat.sh
@@ -8,7 +8,7 @@
 # Copyright 2020-2025 Ramon F. Kolb - licensed under the terms and conditions
 # of GPLv3. The terms and conditions of this license are included with the Github
 # distribution of this package, and are also available here:
-# https://github.com/sdr-enthusiasts/planefence/
+# https://github.com/sdr-enthusiasts/docker-planefence/
 #
 # The package contains parts of, and modifications or derivatives to the following:
 # Dump1090.Socket30003 by Ted Sluis: https://github.com/tedsluis/dump1090.socket30003

--- a/rootfs/usr/share/planefence/send-discord-alert.py
+++ b/rootfs/usr/share/planefence/send-discord-alert.py
@@ -10,7 +10,7 @@
 # Licensed under the terms and conditions
 # of GPLv3. The terms and conditions of this license are included with the Github
 # distribution of this package, and are also available here:
-# https://github.com/sdr-enthusiasts/planefence/
+# https://github.com/sdr-enthusiasts/docker-planefence/
 #
 # The package contains parts of, and modifications or derivatives to the following:
 # Dump1090.Socket30003 by Ted Sluis: https://github.com/tedsluis/dump1090.socket30003


### PR DESCRIPTION
There are a smattering of references to a planefence or a plane-alert repo, which do not exist on 
GitHub. This updates all found references to the sdr-enthusiasts/docker-planefence repo.

