### PR TITLE
Allow planefence favicon to be found when at subdirectory

### DIFF
--- a/rootfs/usr/share/planefence/planefence.sh
+++ b/rootfs/usr/share/planefence/planefence.sh
@@ -860,6 +860,8 @@ cat <<EOF >"$OUTFILEHTMTMP"
 # If not, see https://www.gnu.org/licenses/.
 -->
 <head>
+	<link rel="icon" href="favicon.ico">
+
 EOF
 
 if chk_enabled "${AUTOREFRESH,,}"; then


### PR DESCRIPTION
When hosting planefence on a subdirectory, the lack of a an explicit `<link rel="icon"...">` in the HTML 
means that the browser will fallback and look for a favicon at the server root, which won't be found 
(or it will return the wrong one). By adding an explicit call, the favicon.ico provided at the 
planefence root will be served.

Note that this does not address a similar problem for plane-alert. Plane-alert doesn't have a 
different favicon. Probably the proper thing to do there is to use something like the PF_LINK 
envvar to determine the path to the planefence HTML root. A problem for another day. :wink:

Tested on a local planefence install.
