### PR TITLE
Don't convert MQTT_URL to lowercase

### DIFF
--- a/rootfs/usr/share/planefence/planefence_notify.sh
+++ b/rootfs/usr/share/planefence/planefence_notify.sh
@@ -416,7 +416,6 @@ if [ -f "$CSVFILE" ]; then
 
 				# prep the MQTT host, port, etc
 				unset MQTT_TOPIC MQTT_PORT MQTT_USERNAME MQTT_PASSWORD MQTT_HOST
-				MQTT_HOST="${MQTT_URL,,}"
 				MQTT_HOST="${MQTT_HOST##*:\/\/}"                                                    # strip protocol header (mqtt:// etc)
 				while [[ "${MQTT_HOST: -1}" == "/" ]]; do MQTT_HOST="${MQTT_HOST:0:-1}"; done       # remove any trailing / from the HOST
 				if [[ $MQTT_HOST == *"/"* ]]; then MQTT_TOPIC="${MQTT_TOPIC:-${MQTT_HOST#*\/}}"; fi # if there's no explicitly defined topic, then use the URL's topic if that exists


### PR DESCRIPTION
I was troubleshooting why my MQTT publish wouldn't work.
Turned out the whole MQTT_URL is lowercased, which also lowercased the username / password.

This PR just to remove the lowercasing of the URL, this makes sure that we use the MQTT URL and credentials as configured.