### PR TITLE
Modifying the variable expected to determine if Telegram is enabled. …

### DIFF
--- a/rootfs/usr/share/planefence/planefence.sh
+++ b/rootfs/usr/share/planefence/planefence.sh
@@ -965,7 +965,7 @@ if chk_enabled "$PLANETWEET" \
    || chk_enabled "$PF_MASTODON" \
    || [[ -n "$BLUESKY_HANDLE" ]] \
    || [[ -n "$RSS_SITELINK" ]] \
-	 || chk_enabled "$PF_TELEGRAM_ENABLED" \
+	 || chk_enabled "$TELEGRAM_ENABLED" \
    || [[ -n "$MQTT_URL" ]]; then
 	LOG "Invoking planefence_notify.sh for notifications"
 	$PLANEFENCEDIR/planefence_notify.sh today "$DISTUNIT" "$ALTUNIT"


### PR DESCRIPTION
…Old value was PF_TELEGRAM_ENABLED, but prep-planefence.sh was reading PF_TELEGRAM_ENABLED from the persistent volume and re-aliasing it as TELEGRAM_ENABLED. Therefore, by reading TELEGRAM_ENABLED, planefence_notify.sh will be executed as expected.