### PR TITLE
fix: support private chats (DM) for Telegram notifications

### DIFF
--- a/README-telegram.md
+++ b/README-telegram.md
@@ -43,6 +43,14 @@ The "Copy Message Link" option appears to be available only when you are using a
 1. You must add the bot as a subscriber to the channel. You can only do this if you are an Administrator of the Channel
 2. For the CHAT_ID, feel free to use the `@ChannelName` value, or follow steps 4 and 5 above to get the numeric ID.
 
+### Sending to a private chat (direct messages)
+
+To receive notifications directly to your personal Telegram account:
+
+1. Start a conversation with your bot by clicking "Start"
+2. Use your Telegram user ID as the CHAT_ID
+3. Set `PF_TELEGRAM_CHAT_TYPE` and/or `PA_TELEGRAM_CHAT_TYPE` to `private` (see Step 3)
+
 ## Step 3: Configure Planefence to send notifications to Telegram
 
 Edit your `planefence.config` file, and add or modify the following parameters:
@@ -51,6 +59,8 @@ Edit your `planefence.config` file, and add or modify the following parameters:
 TELEGRAM_BOT_TOKEN=""         # set this parameter to the HTTP API Token you got in Step 1
 PF_TELEGRAM_CHAT_ID=""        # Planefence Chat (channel) ID - set this parameter to the CHAT_ID you got in Step 2
 PA_TELEGRAM_CHAT_ID=""        # Plane-Alert Chat (channel) ID - set this parameter to the CHAT_ID you got in Step 2
+PF_TELEGRAM_CHAT_TYPE=""      # set to "private" for direct messages to a user, leave empty for channels
+PA_TELEGRAM_CHAT_TYPE=""      # set to "private" for direct messages to a user, leave empty for channels
 PF_TELEGRAM_ENABLED=false     # Set this to "on"/"enabled"/"1"/"yes"/"true" to start sending Planefence notifications
 PA_TELEGRAM_ENABLED=false     # Set this to "on"/"enabled"/"1"/"yes"/"true" to start sending Plane-Alert notifications
 ```

--- a/rootfs/usr/share/planefence/stage/planefence.config
+++ b/rootfs/usr/share/planefence/stage/planefence.config
@@ -541,10 +541,20 @@ PA_BLUESKY_ENABLED=""
 # how to create a Telegram Bot and a Telegram Channel to post to. 
 #
 # TELEGRAM_BOT_TOKEN should look like "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ"
-# PF_TELEGRAM_CHAT_ID / PA_TELEGRAM_CHAT_ID can be a numeric ID (for private channels) or a public channel name like "@yourchannel"
 #
-# IMPORTANT: you must add your newly created Bot as an Administrator of your channel. You can only do this if you
-#            yourself are an Administrator of the channel. 
+# PF_TELEGRAM_CHAT_ID / PA_TELEGRAM_CHAT_ID can be:
+# - A numeric channel/supergroup ID (e.g., "1234567890" - will be prefixed with -100 automatically)
+# - A full channel/supergroup ID with -100 prefix (e.g., "-1001234567890")
+# - A public channel username (e.g., "@yourchannel")
+# - A user ID for private messages to a user (e.g., "37560172")
+#
+# PF_TELEGRAM_CHAT_TYPE / PA_TELEGRAM_CHAT_TYPE (optional):
+# Set to "private", "user", or "dm" if you want to send messages directly to a user (private chat).
+# Leave empty or omit for channels/groups (default behavior for backward compatibility).
+# When set to "private", the chat ID will be used as-is without adding -100 prefix.
+#
+# IMPORTANT: For channels, you must add your bot as an Administrator with "Post Messages" permission.
+# For private chats, the user must first start a conversation with your bot.
 #
 # The parameters "PF_TELEGRAM_ENABLED" and "PA_TELEGRAM_ENABLED" must be set to "on"/"enabled"/"1"/"yes"/"true"
 # to start notifications about Planefence and Plane-Alert respectively.
@@ -552,6 +562,8 @@ PA_BLUESKY_ENABLED=""
 TELEGRAM_BOT_TOKEN=""
 PF_TELEGRAM_CHAT_ID=""
 PA_TELEGRAM_CHAT_ID=""
+PF_TELEGRAM_CHAT_TYPE=""
+PA_TELEGRAM_CHAT_TYPE=""
 PF_TELEGRAM_ENABLED=false
 PA_TELEGRAM_ENABLED=false
 #


### PR DESCRIPTION
## Problem

When sending Telegram notifications to a private chat (direct messages to a user), the script fails with:

```
Error sending photo to Telegram: {"ok":false,"error_code":400,"description":"Bad Request: chat not found"}
```

This happens because the script unconditionally adds a `-100` prefix to all chat IDs. While this works for channels and supergroups, it breaks private chats where the user ID should be used as-is.

For example, a user ID `37560172` becomes `-10037560172`, which does not exist.

## Solution

Added new optional configuration parameters `PF_TELEGRAM_CHAT_TYPE` and `PA_TELEGRAM_CHAT_TYPE`. When set to `private`, the chat ID is used without modification.

## Changes

- `rootfs/scripts/post2telegram.sh`: Added logic to detect chat type and skip the `-100` prefix for private chats
- `rootfs/usr/share/planefence/stage/planefence.config`: Added new parameters with documentation
- `README-telegram.md`: Added section describing private chat setup

## Backward Compatibility

Existing configurations continue to work without changes. The new parameters are optional and default to the previous behavior (channel mode with `-100` prefix).

## Usage

For private chats, users need to add:

```
PF_TELEGRAM_CHAT_TYPE=private
PA_TELEGRAM_CHAT_TYPE=private
```