### PR TITLE
mqtt Callback API error fix for classic branch

### DIFF
--- a/rootfs/scripts/mqtt.py
+++ b/rootfs/scripts/mqtt.py
@@ -22,10 +22,11 @@ where:
 
 import argparse
 import paho.mqtt.client as mqtt # type: ignore
+from paho.mqtt.enums import CallbackAPIVersion
 
 def publish_message(broker, port, topic, qos, message, client_id, username=None, password=None):
     # Create an MQTT client instance
-    client = mqtt.Client(client_id)
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, client_id)
 
     # Set username and password if provided
     if username and password:


### PR DESCRIPTION
Since the classic branch and the new branch use different `mqtt.py` scripts, I guess I'm the only one who got the error with the update of 29 May.

```
 File "/usr/lib/python3/dist-packages/paho/mqtt/client.py", line 772, in __init__
    raise ValueError(
        "Unsupported callback API version: version 2.0 added a callback_api_version, see docs/migrations.rst for details"
    )
ValueError: Unsupported callback API version: version 2.0 added a callback_api_version, see docs/migrations.rst for details
```

edited my local file and verified it's sending mqtt messages now.