### PR TITLE
ci: repair red Lint and fix DL3025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ RUN \
 EXPOSE 80
 
 # Add healthcheck
-HEALTHCHECK --start-period=60s --start-interval=10s --interval=600s CMD /scripts/healthcheck.sh
+HEALTHCHECK --start-period=60s --start-interval=10s --interval=600s CMD ["/scripts/healthcheck.sh"]

--- a/rootfs/usr/share/planefence/stage/html-config/index.html
+++ b/rootfs/usr/share/planefence/stage/html-config/index.html
@@ -1064,8 +1064,7 @@
             [...opts].forEach((v) => {
               const o = document.createElement("option");
               o.value = v;
-              o.textContent =
-                optionLabels[v] || (v === "" ? "(empty)" : v);
+              o.textContent = optionLabels[v] || (v === "" ? "(empty)" : v);
               if (v === cur) o.selected = true;
               sel.appendChild(o);
             });


### PR DESCRIPTION
## Problem

Two independent issues. Only the second is about hadolint.

### 1. `Lint` is already red on `main`

`Lint` has been failing since **2026-08-01** — before this branch, and unrelated to hadolint. `prettier` reformats one file and the hook reports the modification:

```text
prettier.................................................................Failed
- hook id: prettier
- files were modified by this hook
```

```text
2026-08-03T16:51  main              failure
2026-08-02T07:38  update-nixpkgs    failure
2026-08-01T17:15  dev               failure
2026-08-01T10:00  renovate/...      success   <- last green
```

Any PR opened against this repo currently inherits that red `Lint`, so it is fixed here first.

### 2. DL3025

hadolint [#1209](https://github.com/hadolint/hadolint/pull/1209) extended `DL3025` to fire on `HEALTHCHECK ... CMD` as well as `CMD`/`ENTRYPOINT`, shipping in v2.15.0 (published 2026-07-30T13:39:01Z). `DL3025` itself is not new; only the `HEALTHCHECK` coverage is.

```console
$ hadolint --config <shared ruleset> Dockerfile     # 2.14.0, the flake.lock pin
rc=0

$ hadolint --config <shared ruleset> Dockerfile     # 2.15.1
Dockerfile:40 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
rc=1
```

`check_docker` is already `true`, so this is a latent `Lint` failure the moment a `flake.lock` bump lands 2.15.x. The live `deploy.yml` has no hadolint job, so the deploy path was never at risk. (`deploy.yml.org` does contain one, but GitHub never executes a `.yml.org` file — left untouched here.)

## Changes

**`style: apply prettier formatting to the config UI`** — repairs the pre-existing red `Lint`. Exactly what prettier 3.8.3 produces:

```diff
-              o.textContent =
-                optionLabels[v] || (v === "" ? "(empty)" : v);
+              o.textContent = optionLabels[v] || (v === "" ? "(empty)" : v);
```

Committed **first** so that every commit in this branch leaves `pre-commit run --all-files` green.

**`fix: use JSON exec form for HEALTHCHECK CMD`**

```diff
-HEALTHCHECK --start-period=60s --start-interval=10s --interval=600s CMD /scripts/healthcheck.sh
+HEALTHCHECK --start-period=60s --start-interval=10s --interval=600s CMD ["/scripts/healthcheck.sh"]
```

## Verification

This is the only Dockerfile in the fleet using `--start-interval`, so flag preservation matters most here. The rebuilt image confirms it survives — only `Test[0]` differs:

```console
built    : {"Test":["CMD","/scripts/healthcheck.sh"],"Interval":600000000000,"StartPeriod":60000000000,"StartInterval":10000000000}
published: {"Test":["CMD-SHELL","/scripts/healthcheck.sh"],"Interval":600000000000,"StartPeriod":60000000000,"StartInterval":10000000000}
```

The exec form drops the intervening `/bin/sh -c`, so the kernel must resolve the script's `#!/command/with-contenv bash` shebang itself — a symlink into the s6-overlay tree, not a normal interpreter path. Both forms run side by side under Docker's real healthcheck machinery — the **published image** (shell form) against a **local build of this branch** (exec form), with only the probe timing overridden:

```text
=== published / shell ===                    === rebuilt / exec ===
healthy                                      healthy
["CMD-SHELL","/scripts/healthcheck.sh"]      ["CMD","/scripts/healthcheck.sh"]
exit=0                                       exit=0
```

Byte-identical output on both sides:

```text
[Wed Aug  5 14:52:28 UTC 2026][HEALTHY] Planefence is UP (Status: 200)
```

Because this probe **passes**, the failure direction was checked separately on the same image — a throwaway layer with `HEALTHCHECK CMD ["/bin/false"]` correctly reports `unhealthy`, `exit=1`.

`Config.Entrypoint` is `["/init"]` on both, so s6 remains PID 1 and `docker stop` still reaches it for graceful shutdown.

`pre-commit run --all-files` was verified green at **each commit individually**, in a detached worktree per commit — not just at the tip:

```text
ee1435b0  pre-commit GREEN  style: apply prettier formatting to the config UI
d74c4e2e  pre-commit GREEN  fix: use JSON exec form for HEALTHCHECK CMD
```

Also checked:

- hadolint clean at 2.14.0 and 2.15.1
- `docker build --platform linux/amd64`: succeeds
- No hooks bypassed; no `--no-verify`
