### PR TITLE
Add generic HTTP webhook notifications for Planefence and Plane-Alert

### DIFF
--- a/README-webhook.md
+++ b/README-webhook.md
@@ -1,0 +1,171 @@
+# Configure Planefence / Plane-Alert HTTP Webhook notifications
+
+- [Configure Planefence / Plane-Alert HTTP Webhook notifications](#configure-planefence--plane-alert-http-webhook-notifications)
+  - [Prerequisites](#prerequisites)
+  - [Step 1: Enable webhooks and set URLs](#step-1-enable-webhooks-and-set-urls)
+  - [Step 2: Choose body format](#step-2-choose-body-format)
+  - [Step 3: Edit persist templates and headers](#step-3-edit-persist-templates-and-headers)
+  - [Placeholders](#placeholders)
+  - [Content-Type behavior](#content-type-behavior)
+  - [Example: ntfy](#example-ntfy)
+  - [Limits and security](#limits-and-security)
+  - [Summary of License Terms](#summary-of-license-terms)
+
+This README describes how to configure Planefence to POST Planefence and/or Plane-Alert alerts to one or more HTTP(S) URLs. These webhooks are generic - they are not built for a specific service. You can use them with ntfy, a small custom endpoint, or anything else that accepts a POST. Discord already has its own notifier; do not use these settings for Discord.
+
+## Prerequisites
+
+This is part of the [sdr-enthusiasts/docker-planefence] docker container. Nothing in this document will make sense outside the context of this container. We assume that Planefence has been set up correctly and is working fine, and all you want to do is add HTTP webhook notifications to your existing setup.
+
+You need an HTTP endpoint that accepts `POST` with a plain-text or JSON body. You can add optional custom headers through persist files (see below).
+
+## Step 1: Enable webhooks and set URLs
+
+Edit your `planefence.config` file (or use the **Notifications -> Webhook** tab in the configuration UI), and set:
+
+```config
+PA_WEBHOOK=OFF              # set ON to enable Plane-Alert HTTP webhook POSTs
+PF_WEBHOOK=OFF              # set ON to enable Planefence HTTP webhook POSTs
+PA_WEBHOOK_URLS=            # comma-separated HTTP(S) URLs for Plane-Alert
+PF_WEBHOOK_URLS=            # comma-separated HTTP(S) URLs for Planefence
+```
+
+Planefence and Plane-Alert each have their own enable flag and URL list. There is no shared "one webhook for both" setting. Every URL on a list gets the same rendered body and headers for that side (Planefence or Plane-Alert).
+
+As elsewhere in Planefence, enable values are things like `ON` / `OFF` (and the usual truthy forms such as `yes` / `true` / `1`).
+
+## Step 2: Choose body format
+
+```config
+PA_WEBHOOK_FORMAT=text      # text | json (default text)
+PF_WEBHOOK_FORMAT=text      # text | json (default text)
+```
+
+- `text` - a single human-readable message body (works well with ntfy and similar services).
+- `json` - a structured JSON object body.
+
+Format is chosen separately for Planefence and for Plane-Alert, not per URL. Invalid or empty values fall back to `text`.
+
+## Step 3: Edit persist templates and headers
+
+Bodies and headers are **not** stored in `planefence.config`. They live as fixed filenames on the Planefence persist volume (defaults are copied in on first run if the files are missing). The Web UI does not edit these file contents; edit them on the host (or inside the persist mount).
+
+|             | Format | Template file              | Headers file         |
+| ----------- | ------ | -------------------------- | -------------------- |
+| Plane-Alert | text   | `webhook.pa.text.template` | `webhook.pa.headers` |
+| Plane-Alert | json   | `webhook.pa.json.template` | `webhook.pa.headers` |
+| Planefence  | text   | `webhook.pf.text.template` | `webhook.pf.headers` |
+| Planefence  | json   | `webhook.pf.json.template` | `webhook.pf.headers` |
+
+Headers files use one `Name: value` line per header. Blank lines and `#` comments are ignored. The defaults that ship in the image are comment-only examples - no secrets.
+
+## Placeholders
+
+Templates and header values may contain `||...||` placeholders.
+
+**Record placeholders** use the same field names as MQTT / alert records (for example `||icao||`, `||tail||`, `||altitude:value||`, `||image:thumblink||`, `||link:map||`, `||db:tag1||`). Missing values become empty strings.
+
+**Composed placeholders** are filled in by the notifier:
+
+| Placeholder      | Meaning                                 |
+| ---------------- | --------------------------------------- |
+| `||title||`      | Short notification title                |
+| `||message||`    | Multi-line summary body                 |
+| `||links||`      | Map / tracker links                     |
+| `||emergency||`  | Emergency squawk prefix when applicable |
+| `||alt_unit||`   | Altitude unit string                    |
+| `||dist_unit||`  | Distance unit string                    |
+| `||speed_unit||` | Speed unit string                       |
+
+For `text` format, blank lines are collapsed after substitution. Discord-only tokens such as `||COLOR||` are not supported here.
+
+## Content-Type behavior
+
+The notifier sets `Content-Type` from the chosen format unless the headers file already sets `Content-Type`:
+
+- `text` -> `text/plain; charset=utf-8`
+- `json` -> `application/json`
+
+If you need a different type, put `Content-Type: ...` in that side's headers file (`webhook.pa.headers` or `webhook.pf.headers`).
+
+## Example: ntfy
+
+[ntfy](https://ntfy.sh/) works well as a webhook target. How you point at a topic depends on the body format:
+
+- **`text`** - put the topic in the URL path (`https://ntfy-host/your-topic`). Optional headers such as `Title:` and `Attach:` are the usual ntfy extras.
+- **`json`** - POST to the **server root** only (`https://ntfy-host/`). The topic must be in the JSON body as `"topic": "..."`. Do not put the topic in the URL for JSON publishes.
+
+### Text
+
+```config
+PA_WEBHOOK=ON
+PA_WEBHOOK_URLS=https://ntfy-host/your-topic
+PA_WEBHOOK_FORMAT=text
+```
+
+Edit `webhook.pa.headers` on the persist volume (do **not** commit tokens to git), for example:
+
+```text
+Authorization: Bearer YOUR_TOKEN
+Title: ||title||
+Attach: ||image:thumblink||
+```
+
+- `Authorization` - whatever your ntfy instance requires (Bearer token, Basic, or omit for open topics).
+- `Title: ||title||` - sets the ntfy notification title.
+- `Attach: ||image:thumblink||` - optional; ntfy can attach by URL when a thumbnail link is available. These webhooks never upload local screenshot files.
+
+### JSON
+
+```config
+PA_WEBHOOK=ON
+PA_WEBHOOK_URLS=https://ntfy-host/
+PA_WEBHOOK_FORMAT=json
+```
+
+Put auth in `webhook.pa.headers` as above (you can omit `Title:` / `Attach:` if those fields are already in the JSON body). Edit `webhook.pa.json.template` so it includes a `"topic"` field. Example for Plane-Alert on ntfy:
+
+```json
+{
+  "topic": "planefence",
+  "title": "Plane-Alert: ||owner|| is flying, ||type|| ||tail||",
+  "message": "||distance:value|| ||dist_unit|| away at ||altitude:value|| ||alt_unit|| (||angle:value|| deg ||angle:name||), Speed ||groundspeed:value|| ||speed_unit||, Track: ||track:value|| deg",
+  "markdown": true,
+  "actions": [
+    {
+      "action": "view",
+      "url": "||link:map||",
+      "label": "Track Plane"
+    }
+  ]
+}
+```
+
+`"topic"` is the ntfy topic name (here both Planefence and Plane-Alert can share `planefence`). Change it if you want a separate topic. The seeded JSON templates already include a `topic` field you can rename. For Planefence, use `PF_WEBHOOK*` and `webhook.pf.json.template` the same way.
+
+### Check it
+
+Restart or wait for the next Planefence cycle, then trigger a watchlist / fence alert and check your ntfy client. If the POST fails, look in the container logs.
+
+The same pattern applies to Planefence with `PF_WEBHOOK*`, `webhook.pf.text.template` / `webhook.pf.json.template`, and `webhook.pf.headers`.
+
+## Limits and security
+
+- There is no multipart upload support. Media is URL-based only (placeholders such as `||image:thumblink||` in the body or in headers like ntfy's `Attach:`). Local screenshot paths are not sent as files.
+- Keep tokens and private URLs on the persist volume (`webhook.*.headers`, `planefence.config` on the host). Do not commit Authorization headers or bearer tokens to a repository.
+- Defaults seeded into persist may include commented ntfy examples; leave real secrets out of those files if you share or version the tree.
+
+## Summary of License Terms
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.

--- a/rootfs/scripts/pf-common
+++ b/rootfs/scripts/pf-common
@@ -540,7 +540,8 @@ CHK_NOTIFICATIONS_ENABLED () {
      { [[ -n "${BLUESKY_APP_PASSWORD}" ]] && [[ -n "$BLUESKY_HANDLE" ]]; } || \
      [[ -n "${MASTODON_ACCESS_TOKEN}" ]] || \
      [[ -n "$MQTT_URL" ]] || \
-     chk_enabled "${TELEGRAM_ENABLED}"; then
+     chk_enabled "${TELEGRAM_ENABLED}" || \
+     chk_enabled "${WEBHOOK_ENABLED}"; then
     return 0
   else
     return 1

--- a/rootfs/usr/share/planefence/config_web_lib.php
+++ b/rootfs/usr/share/planefence/config_web_lib.php
@@ -211,6 +211,8 @@ function pf_cfg_multi_fields(): array {
     'PF_DISCORD_WEBHOOKS' => ',',
     'PF_MQTT_FIELDS' => ',',
     'PA_MQTT_FIELDS' => ',',
+    'PA_WEBHOOK_URLS' => ',',
+    'PF_WEBHOOK_URLS' => ',',
   ];
 }
 
@@ -624,6 +626,7 @@ function pf_cfg_encode_value(string $value): string {
 function pf_cfg_notification_mechanism(string $fieldName): string {
   $n = strtoupper($fieldName);
   if (strpos($n, 'DISCORD') !== false) return 'discord';
+  if (strpos($n, 'WEBHOOK') !== false) return 'webhook';
   if (strpos($n, 'MASTODON') !== false) return 'mastodon';
   if (strpos($n, 'MQTT') !== false) return 'mqtt';
   if (strpos($n, 'RSS') !== false) return 'rss';

--- a/rootfs/usr/share/planefence/notifiers/send_pa_webhook.sh
+++ b/rootfs/usr/share/planefence/notifiers/send_pa_webhook.sh
@@ -1,0 +1,283 @@
+#!/command/with-contenv bash
+#shellcheck shell=bash disable=SC2015,SC2164,SC1090,SC2154,SC1091
+#---------------------------------------------------------------------------------------------
+# Copyright (C) 2022-2026, Ramon F. Kolb (kx1t) and contributors
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+#---------------------------------------------------------------------------------------------
+# This script sends a generic HTTP webhook notification for Plane-Alert
+shopt -s extglob
+
+source /scripts/pf-common
+source /usr/share/planefence/plane-alert.conf
+
+# Resolve webhook-common.sh next to this script, else absolute path
+if [[ -f "${BASH_SOURCE[0]%/*}/webhook-common.sh" ]]; then
+  # shellcheck source=/usr/share/planefence/notifiers/webhook-common.sh
+  source "${BASH_SOURCE[0]%/*}/webhook-common.sh"
+else
+  source /usr/share/planefence/notifiers/webhook-common.sh
+fi
+
+# shellcheck disable=SC2034
+DEBUG="${DEBUG:-false}"
+WEBHOOK_CURL_CONNECT_TIMEOUT="${WEBHOOK_CURL_CONNECT_TIMEOUT:-10}"
+WEBHOOK_CURL_MAX_TIME="${WEBHOOK_CURL_MAX_TIME:-45}"
+WEBHOOK_CURL_RETRY="${WEBHOOK_CURL_RETRY:-1}"
+
+declare -a INDEX STALE link delivery_errors
+
+if ! chk_enabled "$WEBHOOK_ENABLED"; then
+  log_print DEBUG "HTTP webhook notifications not enabled."
+  exit 0
+fi
+
+log_print DEBUG "Hello. Starting Plane-Alert HTTP webhook notification run"
+
+if [[ -z "$WEBHOOK_URLS" ]]; then
+  log_print ERR "No webhook URLs defined (WEBHOOK_URLS / PA_WEBHOOK_URLS). Aborting."
+  exit 1
+fi
+
+format="${WEBHOOK_FORMAT,,}"
+case "$format" in
+  text|json) ;;
+  *)
+    log_print WARNING "WEBHOOK_FORMAT='$WEBHOOK_FORMAT' is not text|json; using text"
+    format=text
+    ;;
+esac
+
+template_path="/usr/share/planefence/persist/webhook.pa.${format}.template"
+headers_path="/usr/share/planefence/persist/webhook.pa.headers"
+
+if [[ ! -f "$template_path" ]]; then
+  log_print ERR "Webhook template missing at $template_path. Aborting."
+  exit 1
+fi
+template_clean="$(<"$template_path")"
+
+pf_notification_init_language >/dev/null
+pf_notification_log_language_warning
+
+export LC_ALL=C
+
+# Pin records date/file for the entire run to avoid midnight rollover races.
+TODAY="${TODAY:-$(date +%y%m%d)}"
+RECORDSDIR="${RECORDSDIR:-/run/planefence}"
+RECORDSFILE="${RECORDSFILE:-$RECORDSDIR/planefence-records-${TODAY}.gz}"
+
+log_print DEBUG "Reading records for HTTP webhook notification"
+READ_RECORDS
+
+log_print DEBUG "Getting indices of records ready for webhook notification and stale records"
+build_index_and_stale INDEX STALE webhook pa
+
+if (( ${#INDEX[@]} )); then
+  log_print DEBUG "Records ready for webhook notification: ${INDEX[*]}"
+else
+  log_print DEBUG "No records ready for webhook notification"
+fi
+if (( ${#STALE[@]} )); then
+  log_print DEBUG "Stale records (no notification will be sent): ${STALE[*]}"
+else
+  log_print DEBUG "No stale records"
+fi
+if (( ${#INDEX[@]} == 0 && ${#STALE[@]} == 0 )); then
+  log_print DEBUG "No records eligible for webhook notification."
+  exit 0
+fi
+
+for idx in "${INDEX[@]}"; do
+  log_print DEBUG "Preparing webhook notification for ${pa_records["$idx":tail]}"
+
+  # --- composed placeholders ---
+  aircraft_text="${pa_records["$idx":owner]:-${pa_records["$idx":callsign]}} (${pa_records["$idx":tail]})"
+  title_text="$(pf_notification_format_string "notify.text.title.pa" "Plane-Alert: {aircraft} first seen at {altitude} above {location}" "aircraft" "$aircraft_text" "altitude" "${pa_records["$idx":altitude:value]} $ALTUNIT" "location" "${pa_records["$idx":nominatim]}")"
+
+  emergency=""
+  squawk="${pa_records["$idx":squawk:value]}"
+  if [[ "$squawk" =~ ^(7500|7600|7700)$ ]]; then
+    emergency="$(pf_notification_format_string "notify.text.emergencyPrefix" "Emergency: Squawk {squawk} - " "squawk" "$squawk")"
+  fi
+
+  # Short multi-line human summary (readable for ntfy and similar)
+  msg_lines=()
+  [[ -n "${pa_records["$idx":icao]}" ]] && msg_lines+=("ICAO: ${pa_records["$idx":icao]}")
+  [[ -n "${pa_records["$idx":tail]}" ]] && msg_lines+=("Tail: ${pa_records["$idx":tail]}")
+  [[ -n "${pa_records["$idx":callsign]}" ]] && msg_lines+=("Callsign: ${pa_records["$idx":callsign]}")
+  [[ -n "${pa_records["$idx":type]}" ]] && msg_lines+=("Type: ${pa_records["$idx":type]}")
+  [[ -n "${pa_records["$idx":owner]}" ]] && msg_lines+=("Owner: ${pa_records["$idx":owner]}")
+  [[ -n "${pa_records["$idx":altitude:value]}" ]] && msg_lines+=("Altitude: ${pa_records["$idx":altitude:value]} $ALTUNIT")
+  [[ -n "${pa_records["$idx":distance:value]}" ]] && msg_lines+=("Distance: ${pa_records["$idx":distance:value]} $DISTUNIT")
+  [[ -n "$squawk" ]] && msg_lines+=("Squawk: $squawk")
+  tags=""
+  [[ -n "${pa_records["$idx":db:tag1]}" ]] && tags+="${tags:+, }${pa_records["$idx":db:tag1]}"
+  [[ -n "${pa_records["$idx":db:tag2]}" ]] && tags+="${tags:+, }${pa_records["$idx":db:tag2]}"
+  [[ -n "${pa_records["$idx":db:tag3]}" ]] && tags+="${tags:+, }${pa_records["$idx":db:tag3]}"
+  [[ -n "$tags" ]] && msg_lines+=("Tags: $tags")
+  message=""
+  if ((${#msg_lines[@]})); then
+    message="$(printf '%s\n' "${msg_lines[@]}")"
+  fi
+
+  links=""
+  if [[ -n "${pa_records["$idx":link:map]}" ]]; then
+    links="${pa_records["$idx":link:map]}"
+  fi
+
+  # message may contain newlines; substitute before pair-based expand (pair format is line-oriented).
+  # For json body, escape so newlines/quotes become \n / \" inside the template's string literals.
+  # Headers stay plain text — flatten CR/LF in all header substitution values (never inject raw multiline message).
+  template="$template_clean"
+  msg_for_body="$(webhook_pair_value "$message" "$format")"
+  msg_repl_body="$(_webhook_escape_repl "$msg_for_body")"
+  template="${template//||message||/${msg_repl_body}}"
+
+  # Body pairs use $'\x1e' record separators so multiline values (e.g. links) stay intact.
+  composed_pairs=""
+  composed_pairs+="title"$'\x1f'"$(webhook_pair_value "$title_text" "$format")"$'\x1e'
+  composed_pairs+="links"$'\x1f'"$(webhook_pair_value "$links" "$format")"$'\x1e'
+  composed_pairs+="emergency"$'\x1f'"$(webhook_pair_value "$emergency" "$format")"$'\x1e'
+  composed_pairs+="alt_unit"$'\x1f'"$(webhook_pair_value "${ALTUNIT}" "$format")"$'\x1e'
+  composed_pairs+="dist_unit"$'\x1f'"$(webhook_pair_value "${DISTUNIT}" "$format")"$'\x1e'
+  composed_pairs+="speed_unit"$'\x1f'"$(webhook_pair_value "${SPEEDUNIT}" "$format")"$'\x1e'
+
+  # Plain composed pairs for HTTP headers — all values flattened to a single line
+  composed_pairs_hdr=""
+  composed_pairs_hdr+="title"$'\x1f'"$(webhook_flatten_header_value "$title_text")"$'\x1e'
+  composed_pairs_hdr+="message"$'\x1f'"$(webhook_flatten_header_value "$message")"$'\x1e'
+  composed_pairs_hdr+="links"$'\x1f'"$(webhook_flatten_header_value "$links")"$'\x1e'
+  composed_pairs_hdr+="emergency"$'\x1f'"$(webhook_flatten_header_value "$emergency")"$'\x1e'
+  composed_pairs_hdr+="alt_unit"$'\x1f'"$(webhook_flatten_header_value "${ALTUNIT}")"$'\x1e'
+  composed_pairs_hdr+="dist_unit"$'\x1f'"$(webhook_flatten_header_value "${DISTUNIT}")"$'\x1e'
+  composed_pairs_hdr+="speed_unit"$'\x1f'"$(webhook_flatten_header_value "${SPEEDUNIT}")"$'\x1e'
+
+  # --- record pairs from pa_records keys matching "$idx:"* ---
+  # Body record pair values must be single-line (pair format is newline-separated).
+  # Header pairs flatten CR/LF instead of skipping.
+  record_pairs=""
+  record_pairs_hdr=""
+  for k in "${!pa_records[@]}"; do
+    [[ "$k" == "$idx:"* ]] || continue
+    suffix="${k#"$idx":}"
+    # Skip noisy internal keys
+    [[ "$suffix" == checked:* ]] && continue
+    [[ "$suffix" == *:notified ]] && continue
+    val="${pa_records[$k]}"
+    record_pairs_hdr+="$suffix"$'\x1f'"$(webhook_flatten_header_value "$val")"$'\x1e'
+    if [[ "$val" == *$'\n'* || "$val" == *$'\r'* ]]; then
+      log_print DEBUG "Skipping multiline record field '$suffix' for webhook body pairs"
+      continue
+    fi
+    record_pairs+="$suffix"$'\x1f'"$(webhook_pair_value "$val" "$format")"$'\x1e'
+  done
+
+  body="$(webhook_expand_placeholders "$template" "$record_pairs" "$composed_pairs")"
+  if [[ "$format" == "text" ]]; then
+    body="$(webhook_collapse_blank_lines "$body")"
+  elif [[ "$format" == "json" ]]; then
+    if ! jq -e . >/dev/null 2>&1 <<<"$body"; then
+      log_print ERR "Webhook body is not valid JSON after template expansion for #$idx ${pa_records["$idx":tail]} (${pa_records["$idx":icao]}); not delivering"
+      delivery_errors[idx]=true
+      continue
+    fi
+  fi
+
+  # --- headers: parse, expand (flattened values only), sanitize, default Content-Type ---
+  headers_src=""
+  if [[ -f "$headers_path" ]]; then
+    headers_src="$(webhook_parse_headers_file "$headers_path")"
+  fi
+  headers_expanded="$(webhook_expand_placeholders "$headers_src" "$record_pairs_hdr" "$composed_pairs_hdr")"
+  headers_expanded="$(webhook_sanitize_headers "$headers_expanded")"
+  if [[ "$(webhook_headers_have_content_type "$headers_expanded")" != "yes" ]]; then
+    headers_expanded+=$'\n'"Content-Type: $(webhook_default_content_type "$format")"
+  fi
+  mapfile -t curl_header_args < <(webhook_build_curl_header_args "$headers_expanded")
+
+  # --- POST to each URL ---
+  readarray -td, webhooks <<<"${WEBHOOK_URLS}"
+  any_success=false
+
+  for url in "${webhooks[@]}"; do
+    url="${url//$'\n'/}"
+    url="${url#"${url%%[![:space:]]*}"}"
+    url="${url%"${url##*[![:space:]]}"}"
+    [[ -z "$url" ]] && continue
+
+    url_suffix="${url: -8}"
+    tmpbody="$(mktemp)"
+    tmperr="$(mktemp)"
+    http_code="$(curl -sS -L \
+      --connect-timeout "$WEBHOOK_CURL_CONNECT_TIMEOUT" \
+      --max-time "$WEBHOOK_CURL_MAX_TIME" \
+      --retry "$WEBHOOK_CURL_RETRY" \
+      --retry-delay 1 \
+      -o "$tmpbody" \
+      -w '%{http_code}' \
+      "${curl_header_args[@]}" \
+      --data-binary "$body" \
+      "$url" 2>"$tmperr")"
+    curl_rc=$?
+    body_snip="$(tr '\n\r' '  ' <"$tmpbody" | head -c 200)"
+    err_snip="$(webhook_sanitize_curl_stderr "$(tr '\n\r' '  ' <"$tmperr" | head -c 400)" "$url")"
+    err_snip="${err_snip:0:200}"
+    rm -f "$tmpbody" "$tmperr"
+
+    if (( curl_rc != 0 )); then
+      log_print WARNING "Webhook notification failed at URL ending in ${url_suffix} for #$idx ${pa_records["$idx":tail]} (${pa_records["$idx":icao]}). curl rc=${curl_rc}: ${err_snip}"
+      delivery_errors[idx]=true
+      continue
+    fi
+    if [[ ! "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+      log_print WARNING "Webhook notification failed at URL ending in ${url_suffix} for #$idx ${pa_records["$idx":tail]} (${pa_records["$idx":icao]}). HTTP ${http_code}: ${body_snip}"
+      delivery_errors[idx]=true
+      continue
+    fi
+    log_print INFO "Webhook notification successful at URL ending in ${url_suffix} for #$idx ${pa_records["$idx":tail]} (${pa_records["$idx":icao]}) (HTTP ${http_code})"
+    any_success=true
+  done
+
+  if $any_success; then
+    link[idx]=true
+  elif [[ -z "${delivery_errors[idx]:-}" ]]; then
+    # No URLs after trim — treat as error
+    delivery_errors[idx]=true
+  fi
+done
+
+# Save the records again
+log_print DEBUG "Updating records after webhook notifications"
+
+LOCK_RECORDS
+READ_RECORDS ignore-lock
+
+if [[ ${#link[@]} -gt 0 || ${#delivery_errors[@]} -gt 0 ]]; then pa_records[HASNOTIFS]=true; fi
+
+for idx in "${STALE[@]}"; do
+  pa_records["$idx":webhook:notified]="stale"
+done
+
+for idx in "${!delivery_errors[@]}"; do
+  pa_records["$idx":webhook:notified]="error"
+done
+
+# Successes win over partial delivery_errors (same as Discord)
+for idx in "${!link[@]}"; do
+  pa_records["$idx":webhook:notified]=true
+done
+
+log_print DEBUG "Saving records..."
+WRITE_RECORDS ignore-lock
+log_print INFO "HTTP webhook notifications run completed."

--- a/rootfs/usr/share/planefence/notifiers/send_pf_webhook.sh
+++ b/rootfs/usr/share/planefence/notifiers/send_pf_webhook.sh
@@ -1,0 +1,294 @@
+#!/command/with-contenv bash
+#shellcheck shell=bash disable=SC2015,SC2164,SC1090,SC2154,SC1091
+#---------------------------------------------------------------------------------------------
+# Copyright (C) 2022-2026, Ramon F. Kolb (kx1t) and contributors
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+#---------------------------------------------------------------------------------------------
+# This script sends a generic HTTP webhook notification for Planefence
+shopt -s extglob
+
+source /scripts/pf-common
+source /usr/share/planefence/planefence.conf
+
+# Resolve webhook-common.sh next to this script, else absolute path
+if [[ -f "${BASH_SOURCE[0]%/*}/webhook-common.sh" ]]; then
+  # shellcheck source=/usr/share/planefence/notifiers/webhook-common.sh
+  source "${BASH_SOURCE[0]%/*}/webhook-common.sh"
+else
+  source /usr/share/planefence/notifiers/webhook-common.sh
+fi
+
+# shellcheck disable=SC2034
+DEBUG="${DEBUG:-false}"
+WEBHOOK_CURL_CONNECT_TIMEOUT="${WEBHOOK_CURL_CONNECT_TIMEOUT:-10}"
+WEBHOOK_CURL_MAX_TIME="${WEBHOOK_CURL_MAX_TIME:-45}"
+WEBHOOK_CURL_RETRY="${WEBHOOK_CURL_RETRY:-1}"
+
+declare -a INDEX STALE link delivery_errors
+
+if ! chk_enabled "$WEBHOOK_ENABLED"; then
+  log_print DEBUG "HTTP webhook notifications not enabled."
+  exit 0
+fi
+
+log_print DEBUG "Hello. Starting Planefence HTTP webhook notification run"
+
+if [[ -z "$WEBHOOK_URLS" ]]; then
+  log_print ERR "No webhook URLs defined (WEBHOOK_URLS / PF_WEBHOOK_URLS). Aborting."
+  exit 1
+fi
+
+format="${WEBHOOK_FORMAT,,}"
+case "$format" in
+  text|json) ;;
+  *)
+    log_print WARNING "WEBHOOK_FORMAT='$WEBHOOK_FORMAT' is not text|json; using text"
+    format=text
+    ;;
+esac
+
+template_path="/usr/share/planefence/persist/webhook.pf.${format}.template"
+headers_path="/usr/share/planefence/persist/webhook.pf.headers"
+
+if [[ ! -f "$template_path" ]]; then
+  log_print ERR "Webhook template missing at $template_path. Aborting."
+  exit 1
+fi
+template_clean="$(<"$template_path")"
+
+pf_notification_init_language >/dev/null
+pf_notification_log_language_warning
+
+export LC_ALL=C
+
+# Pin records date/file for the entire run to avoid midnight rollover races.
+TODAY="${TODAY:-$(date +%y%m%d)}"
+RECORDSDIR="${RECORDSDIR:-/run/planefence}"
+RECORDSFILE="${RECORDSFILE:-$RECORDSDIR/planefence-records-${TODAY}.gz}"
+
+log_print DEBUG "Reading records for HTTP webhook notification"
+READ_RECORDS
+
+log_print DEBUG "Getting indices of records ready for webhook notification and stale records"
+build_index_and_stale INDEX STALE webhook
+
+if (( ${#INDEX[@]} )); then
+  log_print DEBUG "Records ready for webhook notification: ${INDEX[*]}"
+else
+  log_print DEBUG "No records ready for webhook notification"
+fi
+if (( ${#STALE[@]} )); then
+  log_print DEBUG "Stale records (no notification will be sent): ${STALE[*]}"
+else
+  log_print DEBUG "No stale records"
+fi
+if (( ${#INDEX[@]} == 0 && ${#STALE[@]} == 0 )); then
+  log_print DEBUG "No records eligible for webhook notification."
+  exit 0
+fi
+
+for idx in "${INDEX[@]}"; do
+  log_print DEBUG "Preparing webhook notification for ${records["$idx":tail]}"
+
+  # --- composed placeholders ---
+  aircraft_text="${records["$idx":owner]:-${records["$idx":callsign]}} (${records["$idx":tail]})"
+  title_text="$(pf_notification_format_string "notify.text.title.pf" "{aircraft} is at {altitude} above {location}" "aircraft" "$aircraft_text" "altitude" "${records["$idx":altitude:value]} $ALTUNIT" "location" "${records["$idx":nominatim]}")"
+
+  emergency=""
+  squawk="${records["$idx":squawk:value]}"
+  if [[ "$squawk" =~ ^(7500|7600|7700)$ ]]; then
+    emergency="$(pf_notification_format_string "notify.text.emergencyPrefix" "Emergency: Squawk {squawk} - " "squawk" "$squawk")"
+  fi
+
+  # Short multi-line human summary (readable for ntfy and similar)
+  msg_lines=()
+  [[ -n "${records["$idx":icao]}" ]] && msg_lines+=("ICAO: ${records["$idx":icao]}")
+  [[ -n "${records["$idx":tail]}" ]] && msg_lines+=("Tail: ${records["$idx":tail]}")
+  [[ -n "${records["$idx":callsign]}" ]] && msg_lines+=("Callsign: ${records["$idx":callsign]}")
+  [[ -n "${records["$idx":type]}" ]] && msg_lines+=("Type: ${records["$idx":type]}")
+  [[ -n "${records["$idx":owner]}" ]] && msg_lines+=("Owner: ${records["$idx":owner]}")
+  [[ -n "${records["$idx":route]}" && "${records["$idx":route]}" != "n/a" ]] && msg_lines+=("Route: ${records["$idx":route]}")
+  [[ -n "${records["$idx":altitude:value]}" ]] && msg_lines+=("Min Alt: ${records["$idx":altitude:value]} $ALTUNIT")
+  if [[ -n "${records["$idx":distance:value]}" ]]; then
+    dist_line="Min Dist: ${records["$idx":distance:value]} $DISTUNIT"
+    if [[ -n "${records["$idx":angle:value]}" ]]; then
+      dist_line+=" (${records["$idx":angle:value]}°${records["$idx":angle:name]:+ ${records["$idx":angle:name]}})"
+    fi
+    msg_lines+=("$dist_line")
+  fi
+  [[ -n "${records["$idx":groundspeed:value]}" ]] && msg_lines+=("Gnd Speed: ${records["$idx":groundspeed:value]} $SPEEDUNIT")
+  [[ -n "${records["$idx":track:value]}" ]] && msg_lines+=("Track: ${records["$idx":track:value]}°")
+  [[ -n "$squawk" ]] && msg_lines+=("Squawk: $squawk")
+  [[ -n "${records["$idx":sound:loudness]}" ]] && msg_lines+=("Loudness: ${records["$idx":sound:loudness]} dB")
+  message=""
+  if ((${#msg_lines[@]})); then
+    message="$(printf '%s\n' "${msg_lines[@]}")"
+  fi
+
+  links=""
+  if [[ -n "${records["$idx":link:map]}" ]]; then
+    links="${records["$idx":link:map]}"
+  fi
+  if [[ -n "${records["$idx":link:fa]}" ]]; then
+    links+="${links:+$'\n'}${records["$idx":link:fa]}"
+  fi
+  if [[ -n "${records["$idx":link:faa]}" ]]; then
+    links+="${links:+$'\n'}${records["$idx":link:faa]}"
+  fi
+
+  # message may contain newlines; substitute before pair-based expand (pair format is line-oriented).
+  # For json body, escape so newlines/quotes become \n / \" inside the template's string literals.
+  # Headers stay plain text — flatten CR/LF in all header substitution values (never inject raw multiline message).
+  template="$template_clean"
+  msg_for_body="$(webhook_pair_value "$message" "$format")"
+  msg_repl_body="$(_webhook_escape_repl "$msg_for_body")"
+  template="${template//||message||/${msg_repl_body}}"
+
+  # Body pairs use $'\x1e' record separators so multiline values (e.g. links) stay intact.
+  composed_pairs=""
+  composed_pairs+="title"$'\x1f'"$(webhook_pair_value "$title_text" "$format")"$'\x1e'
+  composed_pairs+="links"$'\x1f'"$(webhook_pair_value "$links" "$format")"$'\x1e'
+  composed_pairs+="emergency"$'\x1f'"$(webhook_pair_value "$emergency" "$format")"$'\x1e'
+  composed_pairs+="alt_unit"$'\x1f'"$(webhook_pair_value "${ALTUNIT}" "$format")"$'\x1e'
+  composed_pairs+="dist_unit"$'\x1f'"$(webhook_pair_value "${DISTUNIT}" "$format")"$'\x1e'
+  composed_pairs+="speed_unit"$'\x1f'"$(webhook_pair_value "${SPEEDUNIT}" "$format")"$'\x1e'
+
+  # Plain composed pairs for HTTP headers — all values flattened to a single line
+  composed_pairs_hdr=""
+  composed_pairs_hdr+="title"$'\x1f'"$(webhook_flatten_header_value "$title_text")"$'\x1e'
+  composed_pairs_hdr+="message"$'\x1f'"$(webhook_flatten_header_value "$message")"$'\x1e'
+  composed_pairs_hdr+="links"$'\x1f'"$(webhook_flatten_header_value "$links")"$'\x1e'
+  composed_pairs_hdr+="emergency"$'\x1f'"$(webhook_flatten_header_value "$emergency")"$'\x1e'
+  composed_pairs_hdr+="alt_unit"$'\x1f'"$(webhook_flatten_header_value "${ALTUNIT}")"$'\x1e'
+  composed_pairs_hdr+="dist_unit"$'\x1f'"$(webhook_flatten_header_value "${DISTUNIT}")"$'\x1e'
+  composed_pairs_hdr+="speed_unit"$'\x1f'"$(webhook_flatten_header_value "${SPEEDUNIT}")"$'\x1e'
+
+  # --- record pairs from records keys matching "$idx:"* ---
+  # Body record pair values must be single-line (pair format is newline-separated).
+  # Header pairs flatten CR/LF instead of skipping.
+  record_pairs=""
+  record_pairs_hdr=""
+  for k in "${!records[@]}"; do
+    [[ "$k" == "$idx:"* ]] || continue
+    suffix="${k#"$idx":}"
+    # Skip noisy internal keys
+    [[ "$suffix" == checked:* ]] && continue
+    [[ "$suffix" == *:notified ]] && continue
+    val="${records[$k]}"
+    record_pairs_hdr+="$suffix"$'\x1f'"$(webhook_flatten_header_value "$val")"$'\x1e'
+    if [[ "$val" == *$'\n'* || "$val" == *$'\r'* ]]; then
+      log_print DEBUG "Skipping multiline record field '$suffix' for webhook body pairs"
+      continue
+    fi
+    record_pairs+="$suffix"$'\x1f'"$(webhook_pair_value "$val" "$format")"$'\x1e'
+  done
+
+  body="$(webhook_expand_placeholders "$template" "$record_pairs" "$composed_pairs")"
+  if [[ "$format" == "text" ]]; then
+    body="$(webhook_collapse_blank_lines "$body")"
+  elif [[ "$format" == "json" ]]; then
+    if ! jq -e . >/dev/null 2>&1 <<<"$body"; then
+      log_print ERR "Webhook body is not valid JSON after template expansion for #$idx ${records["$idx":tail]} (${records["$idx":icao]}); not delivering"
+      delivery_errors[idx]=true
+      continue
+    fi
+  fi
+
+  # --- headers: parse, expand (flattened values only), sanitize, default Content-Type ---
+  headers_src=""
+  if [[ -f "$headers_path" ]]; then
+    headers_src="$(webhook_parse_headers_file "$headers_path")"
+  fi
+  headers_expanded="$(webhook_expand_placeholders "$headers_src" "$record_pairs_hdr" "$composed_pairs_hdr")"
+  headers_expanded="$(webhook_sanitize_headers "$headers_expanded")"
+  if [[ "$(webhook_headers_have_content_type "$headers_expanded")" != "yes" ]]; then
+    headers_expanded+=$'\n'"Content-Type: $(webhook_default_content_type "$format")"
+  fi
+  mapfile -t curl_header_args < <(webhook_build_curl_header_args "$headers_expanded")
+
+  # --- POST to each URL ---
+  readarray -td, webhooks <<<"${WEBHOOK_URLS}"
+  any_success=false
+
+  for url in "${webhooks[@]}"; do
+    url="${url//$'\n'/}"
+    url="${url#"${url%%[![:space:]]*}"}"
+    url="${url%"${url##*[![:space:]]}"}"
+    [[ -z "$url" ]] && continue
+
+    url_suffix="${url: -8}"
+    tmpbody="$(mktemp)"
+    tmperr="$(mktemp)"
+    http_code="$(curl -sS -L \
+      --connect-timeout "$WEBHOOK_CURL_CONNECT_TIMEOUT" \
+      --max-time "$WEBHOOK_CURL_MAX_TIME" \
+      --retry "$WEBHOOK_CURL_RETRY" \
+      --retry-delay 1 \
+      -o "$tmpbody" \
+      -w '%{http_code}' \
+      "${curl_header_args[@]}" \
+      --data-binary "$body" \
+      "$url" 2>"$tmperr")"
+    curl_rc=$?
+    body_snip="$(tr '\n\r' '  ' <"$tmpbody" | head -c 200)"
+    err_snip="$(webhook_sanitize_curl_stderr "$(tr '\n\r' '  ' <"$tmperr" | head -c 400)" "$url")"
+    err_snip="${err_snip:0:200}"
+    rm -f "$tmpbody" "$tmperr"
+
+    if (( curl_rc != 0 )); then
+      log_print WARNING "Webhook notification failed at URL ending in ${url_suffix} for #$idx ${records["$idx":tail]} (${records["$idx":icao]}). curl rc=${curl_rc}: ${err_snip}"
+      delivery_errors[idx]=true
+      continue
+    fi
+    if [[ ! "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+      log_print WARNING "Webhook notification failed at URL ending in ${url_suffix} for #$idx ${records["$idx":tail]} (${records["$idx":icao]}). HTTP ${http_code}: ${body_snip}"
+      delivery_errors[idx]=true
+      continue
+    fi
+    log_print INFO "Webhook notification successful at URL ending in ${url_suffix} for #$idx ${records["$idx":tail]} (${records["$idx":icao]}) (HTTP ${http_code})"
+    any_success=true
+  done
+
+  if $any_success; then
+    link[idx]=true
+  elif [[ -z "${delivery_errors[idx]:-}" ]]; then
+    # No URLs after trim — treat as error
+    delivery_errors[idx]=true
+  fi
+done
+
+# Save the records again
+log_print DEBUG "Updating records after webhook notifications"
+
+LOCK_RECORDS
+READ_RECORDS ignore-lock
+
+if [[ ${#link[@]} -gt 0 || ${#delivery_errors[@]} -gt 0 ]]; then records[HASNOTIFS]=true; fi
+
+for idx in "${STALE[@]}"; do
+  records["$idx":webhook:notified]="stale"
+done
+
+for idx in "${!delivery_errors[@]}"; do
+  records["$idx":webhook:notified]="error"
+done
+
+# Successes win over partial delivery_errors (same as Discord)
+for idx in "${!link[@]}"; do
+  records["$idx":webhook:notified]=true
+done
+
+log_print DEBUG "Saving records..."
+WRITE_RECORDS ignore-lock
+log_print INFO "HTTP webhook notifications run completed."

--- a/rootfs/usr/share/planefence/notifiers/webhook-common.sh
+++ b/rootfs/usr/share/planefence/notifiers/webhook-common.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Shared HTTP webhook helpers (placeholder expansion, headers, content-type).
+# Free of Planefence globals so host unit tests can source this file.
+
+# Escape a string for use as the replacement in ${var//pattern/repl}.
+# Bash treats & as "matched text" and \ as the escape character in repl.
+_webhook_escape_repl() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//&/\\&}"
+  printf '%s' "$s"
+}
+
+# Apply one key$'\x1f'value record to text (value may contain newlines).
+_webhook_apply_one_pair() {
+  local text="$1"
+  local line="$2"
+  local key value repl
+  [[ -z "$line" ]] && { printf '%s' "$text"; return; }
+  key="${line%%$'\x1f'*}"
+  value="${line#*$'\x1f'}"
+  [[ -z "$key" || "$key" == "$line" ]] && { printf '%s' "$text"; return; }
+  repl="$(_webhook_escape_repl "$value")"
+  text="${text//||${key}||/${repl}}"
+  printf '%s' "$text"
+}
+
+# Apply key/value pairs to replace ||key|| in text.
+# Preferred: records separated by $'\x1e' so values may contain newlines
+#   (key$'\x1f'value$'\x1e'…).
+# Legacy: newline-separated single-line values (key$'\x1f'value\n…).
+# Unknown tokens are left for a later pass to clear.
+_webhook_apply_pairs() {
+  local text="$1"
+  local pairs="$2"
+  local line
+  if [[ "$pairs" == *$'\x1e'* ]]; then
+    while IFS= read -r -d $'\x1e' line || [[ -n "$line" ]]; do
+      text="$(_webhook_apply_one_pair "$text" "$line")"
+    done <<<"$pairs"
+  else
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      text="$(_webhook_apply_one_pair "$text" "$line")"
+    done <<<"$pairs"
+  fi
+  printf '%s' "$text"
+}
+
+# webhook_expand_placeholders <template> <record_pairs> [composed_pairs]
+# Composed applied first (wins on same key), then record for remaining tokens.
+# Any leftover ||...|| → empty.
+webhook_expand_placeholders() {
+  local template="${1-}"
+  local record_pairs="${2-}"
+  local composed_pairs="${3-}"
+  local out
+  out="$(_webhook_apply_pairs "$template" "$composed_pairs")"
+  out="$(_webhook_apply_pairs "$out" "$record_pairs")"
+  # Clear any remaining ||token|| placeholders
+  while [[ "$out" =~ \|\|[^|]+\|\| ]]; do
+    out="${out//${BASH_REMATCH[0]}/}"
+  done
+  printf '%s' "$out"
+}
+
+# Collapse 3+ consecutive newlines to a single blank line (\n\n),
+# then trim trailing excess blank lines (keep at most one trailing newline).
+webhook_collapse_blank_lines() {
+  local text="${1-}"
+  while [[ "$text" == *$'\n\n\n'* ]]; do
+    text="${text//$'\n\n\n'/$'\n\n'}"
+  done
+  while [[ "$text" == *$'\n\n' ]]; do
+    text="${text%$'\n'}"
+  done
+  printf '%s' "$text"
+}
+
+# Print Name: value lines; skip # comments and blank lines.
+webhook_parse_headers_file() {
+  local path="${1-}"
+  local line
+  [[ -f "$path" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # trim trailing CR if present
+    line="${line%$'\r'}"
+    [[ -z "$line" ]] && continue
+    [[ "$line" == \#* ]] && continue
+    printf '%s\n' "$line"
+  done <"$path"
+}
+
+webhook_default_content_type() {
+  case "${1-}" in
+    text) printf '%s' 'text/plain; charset=utf-8' ;;
+    json) printf '%s' 'application/json' ;;
+    *) printf '%s' 'text/plain; charset=utf-8' ;;
+  esac
+}
+
+# yes/no if headers text already contains Content-Type: (case-insensitive)
+webhook_headers_have_content_type() {
+  local headers="${1-}"
+  local line
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    if [[ "${line,,}" == content-type:* ]]; then
+      printf 'yes'
+      return 0
+    fi
+  done <<<"$headers"
+  printf 'no'
+}
+
+# Given newline-separated expanded header lines, print curl argv pairs:
+#   -H
+#   Name: value
+# one pair per header (stdout lines; mapfile-friendly).
+webhook_build_curl_header_args() {
+  local headers="${1-}"
+  local line
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    [[ -z "$line" ]] && continue
+    printf '%s\n' '-H'
+    printf '%s\n' "$line"
+  done <<<"$headers"
+}
+
+# Sanitize curl stderr for logs: replace known URL and any http(s)://… with <url>.
+# Usage: webhook_sanitize_curl_stderr <stderr_text> [request_url]
+webhook_sanitize_curl_stderr() {
+  local err="${1-}"
+  local url="${2-}"
+  if [[ -n "$url" ]]; then
+    err="${err//"$url"/<url>}"
+  fi
+  # Redact remaining absolute URLs (query tokens, basic-auth userinfo, etc.)
+  err="$(sed -E 's#https?://[^[:space:]'\''\"<>]+#<url>#g' <<<"$err")"
+  printf '%s' "$err"
+}
+
+# Escape for embedding inside a JSON string literal (no surrounding quotes).
+webhook_json_string_escape() {
+  jq -rn --arg s "${1-}" '$s|@json' | sed 's/^"//;s/"$//'
+}
+
+# Value for placeholder pairs: JSON-escape when format is json, else raw.
+# Usage: webhook_pair_value <value> <text|json>
+webhook_pair_value() {
+  local value="${1-}"
+  local format="${2:-text}"
+  if [[ "$format" == "json" ]]; then
+    webhook_json_string_escape "$value"
+  else
+    printf '%s' "$value"
+  fi
+}
+
+# Flatten CR/LF in values used for HTTP header expansion.
+webhook_flatten_header_value() {
+  local s="${1-}"
+  s="${s//$'\r'/ }"
+  s="${s//$'\n'/ }"
+  printf '%s' "$s"
+}
+
+_webhook_warn() {
+  if declare -F log_print >/dev/null 2>&1; then
+    log_print WARNING "$1"
+  else
+    printf 'WARNING: %s\n' "$1" >&2
+  fi
+}
+
+# Strip CR; keep only single-line Name: value headers (skip malformed / injected lines).
+webhook_sanitize_headers() {
+  local raw="${1-}"
+  local line
+  raw="${raw//$'\r'/}"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" ]] && continue
+    if [[ "$line" == *$'\n'* || "$line" == *$'\r'* ]]; then
+      _webhook_warn "Skipping header line containing newline after expansion"
+      continue
+    fi
+    if [[ "$line" != *:* ]]; then
+      _webhook_warn "Skipping header line without Name: value form after expansion"
+      continue
+    fi
+    printf '%s\n' "$line"
+  done <<<"$raw"
+}

--- a/rootfs/usr/share/planefence/pf-run.sh
+++ b/rootfs/usr/share/planefence/pf-run.sh
@@ -125,7 +125,7 @@ fi
 sync_notifier_links_into_json() {
   local mode="$1" json_file="$2"
   local max idx tmp_map tmp_json tmp_map_new
-  local discord_link discord_notified bsky_link bsky_notified telegram_link telegram_notified mastodon_link mastodon_notified mqtt_notified
+  local discord_link discord_notified bsky_link bsky_notified telegram_link telegram_notified mastodon_link mastodon_notified mqtt_notified webhook_notified
 
   [[ -f "$json_file" ]] || return 0
 
@@ -150,6 +150,7 @@ sync_notifier_links_into_json() {
         mastodon_link="${pa_records["$idx:mastodon:link"]}"
         mastodon_notified="${pa_records["$idx:mastodon:notified"]}"
         mqtt_notified="${pa_records["$idx:mqtt:notified"]}"
+        webhook_notified="${pa_records["$idx:webhook:notified"]}"
       else
         discord_link="${records["$idx:discord:link"]}"
         discord_notified="${records["$idx:discord:notified"]}"
@@ -160,9 +161,10 @@ sync_notifier_links_into_json() {
         mastodon_link="${records["$idx:mastodon:link"]}"
         mastodon_notified="${records["$idx:mastodon:notified"]}"
         mqtt_notified="${records["$idx:mqtt:notified"]}"
+        webhook_notified="${records["$idx:webhook:notified"]}"
       fi
 
-      if [[ -n "$discord_link$discord_notified$bsky_link$bsky_notified$telegram_link$telegram_notified$mastodon_link$mastodon_notified$mqtt_notified" ]]; then
+      if [[ -n "$discord_link$discord_notified$bsky_link$bsky_notified$telegram_link$telegram_notified$mastodon_link$mastodon_notified$mqtt_notified$webhook_notified" ]]; then
         tmp_map_new="$(mktemp)"
         jq \
           --arg idx "$idx" \
@@ -175,6 +177,7 @@ sync_notifier_links_into_json() {
           --arg mlink "$mastodon_link" \
           --arg mnot "$mastodon_notified" \
           --arg qnot "$mqtt_notified" \
+          --arg wnot "$webhook_notified" \
           '. + {($idx): {
             "discord:link": $dlink,
             "discord:notified": $dnot,
@@ -184,7 +187,8 @@ sync_notifier_links_into_json() {
             "telegram:notified": $tnot,
             "mastodon:link": $mlink,
             "mastodon:notified": $mnot,
-            "mqtt:notified": $qnot
+            "mqtt:notified": $qnot,
+            "webhook:notified": $wnot
           }}' \
           "$tmp_map" > "$tmp_map_new" && mv -f "$tmp_map_new" "$tmp_map"
       fi

--- a/rootfs/usr/share/planefence/plane-alert.conf
+++ b/rootfs/usr/share/planefence/plane-alert.conf
@@ -169,6 +169,14 @@
 	DISCORD_WEBHOOKS="$PA_DISCORD_WEBHOOKS"
 	DISCORD_COLOR="$PA_DISCORD_COLOR"
 
+# HTTP webhook notifications (see README-webhook.md)
+	PA_WEBHOOK=false
+	PA_WEBHOOK_URLS=
+	PA_WEBHOOK_FORMAT=text
+	WEBHOOK_ENABLED="$PA_WEBHOOK"
+	WEBHOOK_URLS="$PA_WEBHOOK_URLS"
+	WEBHOOK_FORMAT="${PA_WEBHOOK_FORMAT:-text}"
+
 # MASTODON parameters for MASTODON notifications as an alternative to Twitter:
 # MASTODON_SERVER contains the mastodon server name, for example "airwaves.social"
 # MASTODON_NAME contains the @ name of the Mastodon account

--- a/rootfs/usr/share/planefence/planefence.conf
+++ b/rootfs/usr/share/planefence/planefence.conf
@@ -350,6 +350,14 @@ set -a
 #     Planefence:
 #       Same as "screenshot"
 	DISCORD_MEDIA=
+
+# HTTP webhook notifications (see README-webhook.md)
+	PF_WEBHOOK=false
+	PF_WEBHOOK_URLS=
+	PF_WEBHOOK_FORMAT=text
+	WEBHOOK_ENABLED="$PF_WEBHOOK"
+	WEBHOOK_URLS="$PF_WEBHOOK_URLS"
+	WEBHOOK_FORMAT="${PF_WEBHOOK_FORMAT:-text}"
 #
 set +a
 # MASTODON parameters for MASTODON notifications as an alternative to Twitter:

--- a/rootfs/usr/share/planefence/prep-planefence.sh
+++ b/rootfs/usr/share/planefence/prep-planefence.sh
@@ -81,7 +81,27 @@ rm -f /usr/share/planefence/html/index.html 2>/dev/null || true
 cp -R --remove-destination /usr/share/planefence/stage/html/. /usr/share/planefence/html/
 	cp -R --remove-destination /usr/share/planefence/stage/html-config/. /usr/share/planefence/html-config/
 	# always update to latest version
+# Webhook templates/headers are user-owned (ADR 0001): snapshot before --update so
+# newer stage seeds cannot clobber customized files or Authorization secrets.
+_webhook_seed_names=(
+  webhook.pa.headers webhook.pf.headers
+  webhook.pa.text.template webhook.pa.json.template
+  webhook.pf.text.template webhook.pf.json.template
+)
+_webhook_bak="$(mktemp -d)"
+for _webhook_seed in "${_webhook_seed_names[@]}"; do
+  if [[ -e "/usr/share/planefence/persist/${_webhook_seed}" ]]; then
+    cp -a "/usr/share/planefence/persist/${_webhook_seed}" "${_webhook_bak}/"
+  fi
+done
 cp -R --update /usr/share/planefence/stage/persist/* /usr/share/planefence/persist	# only if it doesn't exist yet
+for _webhook_seed in "${_webhook_seed_names[@]}"; do
+  if [[ -e "${_webhook_bak}/${_webhook_seed}" ]]; then
+    cp -a "${_webhook_bak}/${_webhook_seed}" "/usr/share/planefence/persist/${_webhook_seed}"
+  fi
+done
+rm -rf "${_webhook_bak}"
+unset _webhook_seed _webhook_seed_names _webhook_bak
 if [[ -f /usr/share/planefence/stage/Silhouettes.zip ]]; then cp -f /usr/share/planefence/stage/Silhouettes.zip /tmp/silhouettes-org.zip; fi
 
 # PF_WEBLOGS controls where the logs page is exposed:
@@ -270,6 +290,12 @@ configure_planefence "PF_DISCORD_COLOR" "$PF_DISCORD_COLOR"
 configure_both "DISCORD_FEEDER_NAME" "${DISCORD_FEEDER_NAME}"
 configure_both "DISCORD_MEDIA" "${DISCORD_MEDIA}"
 configure_both "DISCORD_AVATAR_URL" "${DISCORD_AVATAR_URL}"
+configure_planealert "PA_WEBHOOK" "$PA_WEBHOOK"
+configure_planefence "PF_WEBHOOK" "$PF_WEBHOOK"
+configure_planealert "PA_WEBHOOK_URLS" "${PA_WEBHOOK_URLS}"
+configure_planefence "PF_WEBHOOK_URLS" "${PF_WEBHOOK_URLS}"
+configure_planealert "PA_WEBHOOK_FORMAT" "${PA_WEBHOOK_FORMAT:-text}"
+configure_planefence "PF_WEBHOOK_FORMAT" "${PF_WEBHOOK_FORMAT:-text}"
 #configure_both "NOTIFICATION_SERVER" "$NOTIFICATION_SERVER"
 configure_both "GENERATE_CSV" "${GENERATE_CSV:-OFF}"
 

--- a/rootfs/usr/share/planefence/stage/persist/.internal/config-ui.schema.json
+++ b/rootfs/usr/share/planefence/stage/persist/.internal/config-ui.schema.json
@@ -91,6 +91,11 @@
           "id": "notif-telegram",
           "title": "Telegram",
           "match": "telegram"
+        },
+        {
+          "id": "notif-webhook",
+          "title": "Webhook",
+          "match": "webhook"
         }
       ]
     }
@@ -365,6 +370,40 @@
     "PA_MQTT_PASSWORD": {
       "type": "text",
       "description": "Optional Plane-Alert MQTT password."
+    },
+    "PA_WEBHOOK": {
+      "type": "select",
+      "options": ["ON", "OFF"],
+      "description": "Enable HTTP webhook POSTs for Plane-Alert. Templates: webhook.pa.text.template / webhook.pa.json.template; headers: webhook.pa.headers (persist volume)."
+    },
+    "PF_WEBHOOK": {
+      "type": "select",
+      "options": ["ON", "OFF"],
+      "description": "Enable HTTP webhook POSTs for Planefence. Templates: webhook.pf.text.template / webhook.pf.json.template; headers: webhook.pf.headers (persist volume)."
+    },
+    "PA_WEBHOOK_URLS": {
+      "type": "text",
+      "multi": true,
+      "description": "Comma-separated HTTP(S) URLs to POST Plane-Alert webhooks to. Every URL receives the same body and headers."
+    },
+    "PF_WEBHOOK_URLS": {
+      "type": "text",
+      "multi": true,
+      "description": "Comma-separated HTTP(S) URLs to POST Planefence webhooks to. Every URL receives the same body and headers."
+    },
+    "PA_WEBHOOK_FORMAT": {
+      "type": "select",
+      "options": ["text", "json"],
+      "defaultValue": "text",
+      "useDefaultWhenEmpty": true,
+      "description": "Plane-Alert webhook body format. text uses webhook.pa.text.template; json uses webhook.pa.json.template."
+    },
+    "PF_WEBHOOK_FORMAT": {
+      "type": "select",
+      "options": ["text", "json"],
+      "defaultValue": "text",
+      "useDefaultWhenEmpty": true,
+      "description": "Planefence webhook body format. text uses webhook.pf.text.template; json uses webhook.pf.json.template."
     }
   }
 }

--- a/rootfs/usr/share/planefence/stage/persist/planefence.config.RENAME-and-EDIT-me
+++ b/rootfs/usr/share/planefence/stage/persist/planefence.config.RENAME-and-EDIT-me
@@ -326,6 +326,24 @@ DISCORD_MEDIA=screenshot+photo
 PA_DISCORD_COLOR=0xf2e718
 PF_DISCORD_COLOR=0xf2e718
 
+# Webhook Notifications
+# ---------------------------------------------------------------------
+# PA_WEBHOOK / PF_WEBHOOK: set ON to enable HTTP webhook POSTs for Plane-Alert / Planefence.
+PA_WEBHOOK=OFF
+PF_WEBHOOK=OFF
+# ---------------------------------------------------------------------
+# PA_WEBHOOK_URLS: comma-separated HTTP(S) URLs to POST Plane-Alert webhooks to.
+PA_WEBHOOK_URLS=
+# PF_WEBHOOK_URLS: comma-separated HTTP(S) URLs to POST Planefence webhooks to.
+PF_WEBHOOK_URLS=
+# ---------------------------------------------------------------------
+# PA_WEBHOOK_FORMAT / PF_WEBHOOK_FORMAT: text | json (default text).
+# Bodies: persist files webhook.pa|pf.text|json.template
+# Headers: persist files webhook.pa|pf.headers
+# See README-webhook.md
+PA_WEBHOOK_FORMAT=text
+PF_WEBHOOK_FORMAT=text
+
 # Mastodon Notifications
 # ---------------------------------------------------------------------
 # PF_MASTODON / PA_MASTODON: enable Mastodon notifications for PF / PA.

--- a/rootfs/usr/share/planefence/stage/persist/webhook.pa.headers
+++ b/rootfs/usr/share/planefence/stage/persist/webhook.pa.headers
@@ -1,0 +1,8 @@
+# Optional HTTP headers for Plane-Alert webhooks (one "Name: value" per line).
+# Examples for ntfy:
+#   Authorization: Bearer YOUR_TOKEN
+#   Title: ||title||
+#   Priority: 3
+#   Tags: airplane
+#   Attach: ||image:thumblink||
+# Placeholders use the same ||name|| syntax as webhook templates.

--- a/rootfs/usr/share/planefence/stage/persist/webhook.pa.json.template
+++ b/rootfs/usr/share/planefence/stage/persist/webhook.pa.json.template
@@ -1,0 +1,21 @@
+{
+  "topic": "planealert",
+  "source": "plane-alert",
+  "title": "||title||",
+  "message": "||message||",
+  "icao": "||icao||",
+  "tail": "||tail||",
+  "callsign": "||callsign||",
+  "type": "||type||",
+  "owner": "||owner||",
+  "altitude": "||altitude:value||",
+  "altitude_unit": "||alt_unit||",
+  "distance": "||distance:value||",
+  "distance_unit": "||dist_unit||",
+  "squawk": "||squawk:value||",
+  "tag1": "||db:tag1||",
+  "tag2": "||db:tag2||",
+  "tag3": "||db:tag3||",
+  "map_link": "||link:map||",
+  "image": "||image:thumblink||"
+}

--- a/rootfs/usr/share/planefence/stage/persist/webhook.pa.text.template
+++ b/rootfs/usr/share/planefence/stage/persist/webhook.pa.text.template
@@ -1,0 +1,5 @@
+||emergency||||title||
+
+||message||
+
+||links||

--- a/rootfs/usr/share/planefence/stage/persist/webhook.pf.headers
+++ b/rootfs/usr/share/planefence/stage/persist/webhook.pf.headers
@@ -1,0 +1,8 @@
+# Optional HTTP headers for Planefence webhooks (one "Name: value" per line).
+# Examples for ntfy:
+#   Authorization: Bearer YOUR_TOKEN
+#   Title: ||title||
+#   Priority: 3
+#   Tags: airplane
+#   Attach: ||image:thumblink||
+# Placeholders use the same ||name|| syntax as webhook templates.

--- a/rootfs/usr/share/planefence/stage/persist/webhook.pf.json.template
+++ b/rootfs/usr/share/planefence/stage/persist/webhook.pf.json.template
@@ -1,0 +1,21 @@
+{
+  "topic": "planefence",
+  "source": "planefence",
+  "title": "||title||",
+  "message": "||message||",
+  "icao": "||icao||",
+  "tail": "||tail||",
+  "callsign": "||callsign||",
+  "type": "||type||",
+  "owner": "||owner||",
+  "altitude": "||altitude:value||",
+  "altitude_unit": "||alt_unit||",
+  "distance": "||distance:value||",
+  "distance_unit": "||dist_unit||",
+  "squawk": "||squawk:value||",
+  "tag1": "||db:tag1||",
+  "tag2": "||db:tag2||",
+  "tag3": "||db:tag3||",
+  "map_link": "||link:map||",
+  "image": "||image:thumblink||"
+}

--- a/rootfs/usr/share/planefence/stage/persist/webhook.pf.text.template
+++ b/rootfs/usr/share/planefence/stage/persist/webhook.pf.text.template
@@ -1,0 +1,5 @@
+||emergency||||title||
+
+||message||
+
+||links||

--- a/tests/webhook/run.sh
+++ b/tests/webhook/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/test_webhook_common.sh"

--- a/tests/webhook/test_webhook_common.sh
+++ b/tests/webhook/test_webhook_common.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=/dev/null
+source "$ROOT/rootfs/usr/share/planefence/notifiers/webhook-common.sh"
+
+fail=0
+assert_eq() {
+  local name="$1" got="$2" want="$3"
+  if [[ "$got" != "$want" ]]; then
+    printf 'FAIL %s\n  got:  %q\n  want: %q\n' "$name" "$got" "$want" >&2
+    fail=1
+  else
+    printf 'PASS %s\n' "$name"
+  fi
+}
+
+# Record placeholder
+out="$(webhook_expand_placeholders 'Hello ||icao||' $'icao\x1fABC123')"
+assert_eq "record field" "$out" "Hello ABC123"
+
+# Missing → empty
+out="$(webhook_expand_placeholders 'X||tail||Y' $'icao\x1fABC123')"
+assert_eq "missing empty" "$out" "XY"
+
+# Composed (pass via composed map)
+out="$(webhook_expand_placeholders '||title||' '' $'title\x1fPlane-Alert: N123')"
+assert_eq "composed title" "$out" "Plane-Alert: N123"
+
+# Same key: composed wins over record
+out="$(webhook_expand_placeholders '||icao||' $'icao\x1fREC' $'icao\x1fCOMP')"
+assert_eq "composed wins" "$out" "COMP"
+
+# Ampersand in value must not be treated as matched-text (&) by bash ${//}
+out="$(webhook_expand_placeholders '||x||' $'x\x1fA&B')"
+assert_eq "ampersand value" "$out" "A&B"
+
+out="$(webhook_expand_placeholders 'link=||u||' $'u\x1fhttps://x.com?a=1&b=2')"
+assert_eq "url query ampersand" "$out" "link=https://x.com?a=1&b=2"
+
+# Text blank-line collapse
+# Sentinel avoids bash $(...) stripping trailing newlines from the capture.
+out="$(webhook_collapse_blank_lines $'a\n\n\nb\n'; printf x)"
+out="${out%x}"
+assert_eq "collapse blanks" "$out" $'a\n\nb\n'
+
+# Headers parse: skip comments/blank; keep Header: value
+tmp="$(mktemp)"
+printf '%s\n' '# comment' '' 'Title: Hi' 'Authorization: Bearer tok' >"$tmp"
+mapfile -t hdrs < <(webhook_parse_headers_file "$tmp")
+assert_eq "header count" "${#hdrs[@]}" "2"
+assert_eq "header0" "${hdrs[0]}" "Title: Hi"
+rm -f "$tmp"
+
+# curl -H argv lines: alternating -H and header value
+mapfile -t carg < <(webhook_build_curl_header_args $'Title: Hi\nAuthorization: Bearer tok')
+assert_eq "curl -H count" "${#carg[@]}" "4"
+assert_eq "curl -H0" "${carg[0]}" "-H"
+assert_eq "curl title" "${carg[1]}" "Title: Hi"
+assert_eq "curl -H2" "${carg[2]}" "-H"
+assert_eq "curl auth" "${carg[3]}" "Authorization: Bearer tok"
+
+# Content-Type default
+assert_eq "ct text" "$(webhook_default_content_type text)" "text/plain; charset=utf-8"
+assert_eq "ct json" "$(webhook_default_content_type json)" "application/json"
+
+# Override detection
+assert_eq "has ct" "$(webhook_headers_have_content_type $'Title: x\nContent-Type: text/html')" "yes"
+assert_eq "no ct" "$(webhook_headers_have_content_type $'Title: x')" "no"
+
+# Multiline composed values use \x1e as record separator (values may contain newlines)
+out="$(webhook_expand_placeholders $'Links:\n||links||' '' $'links\x1fhttp://map\nhttp://fa\x1e')"
+assert_eq "multiline composed links" "$out" $'Links:\nhttp://map\nhttp://fa'
+
+# Multiple \x1e records; second is single-line
+out="$(webhook_expand_placeholders '||title|| ||links||' '' $'title\x1fHi\x1elinks\x1fa\nb\x1e')"
+assert_eq "x1e multi records" "$out" $'Hi a\nb'
+
+# curl stderr sanitization: drop known URL and other http(s) URLs
+err="$(webhook_sanitize_curl_stderr 'curl: (7) Failed to connect to https://user:secret@ntfy.example/topic' 'https://user:secret@ntfy.example/topic')"
+assert_eq "sanitize known url" "$err" "curl: (7) Failed to connect to <url>"
+err="$(webhook_sanitize_curl_stderr 'see https://evil.example/a?token=x and done' '')"
+assert_eq "sanitize other url" "$err" "see <url> and done"
+
+# Shared notifier helpers moved into webhook-common
+assert_eq "pair text" "$(webhook_pair_value 'a"b' text)" 'a"b'
+if command -v jq >/dev/null 2>&1; then
+  assert_eq "pair json" "$(webhook_pair_value $'a"b\nc' json)" 'a\"b\nc'
+else
+  printf 'SKIP pair json (jq not installed)\n'
+fi
+assert_eq "flatten nl" "$(webhook_flatten_header_value $'a\nb')" "a b"
+cr_in="$(printf 'x\ry')"
+assert_eq "flatten cr" "$(webhook_flatten_header_value "$cr_in")" "x y"
+mapfile -t shdr < <(webhook_sanitize_headers $'Title: ok\nbadline\nX-Y: z')
+assert_eq "sanitize hdr count" "${#shdr[@]}" "2"
+assert_eq "sanitize hdr0" "${shdr[0]}" "Title: ok"
+assert_eq "sanitize hdr1" "${shdr[1]}" "X-Y: z"
+
+exit "$fail"


### PR DESCRIPTION
## Summary

- Adds optional HTTP(S) webhook POSTs for Planefence and Plane-Alert, with separate enable flags, URL lists, and text/json format settings per side.
- Bodies and headers come from persist-backed templates (`webhook.{pa|pf}.{text|json}.template` and `webhook.{pa|pf}.headers`) with `||placeholder||` expansion.
- Adds a Webhook subtab under Notifications in the config UI, seeds default persist files without overwriting user edits, and documents setup in `README-webhook.md`.
- Includes shared notifier helpers plus unit tests under `tests/webhook/`.

Closes #382

## Test plan

- [ ] Enable Plane-Alert webhooks in text mode, point at a test endpoint (or ntfy topic URL), trigger an alert, confirm POST body and headers.
- [ ] Switch Plane-Alert to JSON mode, POST to server root with topic in the JSON body, confirm valid JSON and successful delivery.
- [ ] Repeat for Planefence (`PF_WEBHOOK*`) in text and JSON modes.
- [ ] Confirm custom headers (for example Authorization) are sent, and secrets stay on the persist volume.
- [ ] Confirm existing webhook persist files are not overwritten on container restart when stage seeds are newer.
- [ ] Confirm Discord / other existing notifiers are unchanged when webhooks are OFF.
- [ ] Run `tests/webhook/run.sh` (jq optional; JSON pair escape test skips if jq is missing).
