### PR TITLE
perf(plane-alert): match records with an awk hash join instead of grep -E -f

### DIFF
--- a/rootfs/usr/share/planefence/pf-process_sbs.sh
+++ b/rootfs/usr/share/planefence/pf-process_sbs.sh
@@ -1279,8 +1279,19 @@ fi
 
 # Create pa_socketrecords array
 if chk_enabled "$PLANEALERT" && (( $(wc -l < /tmp/pa_keys_$$) > 0 )); then
-  # Patterns in /tmp/pa_keys_$$ are regular expressions anchored with ^, so use regex grep
-  readarray -t pa_socketrecords < <(grep -E -f /tmp/pa_keys_$$ /tmp/filtered_records_$$ 2>/dev/null | awk -F, -v dist="$PA_RANGE" '$8 <= dist && NF==12 { print }' || true)
+  # Match records against the Plane-Alert list with an awk hash join instead of
+  # "grep -E -f": with tens of thousands of anchored "^ICAO," patterns, grep spends
+  # seconds per run compiling the alternation before it reads a single record, and
+  # that cost grows with the size of the list, not the number of records. The join
+  # keys on field 1 (ICAO) and, for the squawk patterns, on field 9 (squawk); the
+  # output lines are the same as the grep version, in the same order.
+  pa_join_db="$PA_FILE"; [[ -f "$pa_join_db" ]] || pa_join_db=/dev/null
+  readarray -t pa_socketrecords < <(awk -F',' -v sqlist="${SQUAWKS[*]:-}" '
+      BEGIN { n = split(sqlist, sq, " ") }
+      FILENAME == ARGV[1] { if (FNR > 1) key[$1] = 1; next }
+      ($1 in key) { print; next }
+      { for (i = 1; i <= n; i++) if ($9 == sq[i]) { print; next } }' \
+      "$pa_join_db" /tmp/filtered_records_$$ 2>/dev/null | awk -F, -v dist="$PA_RANGE" '$8 <= dist && NF==12 { print }' || true)
   rm -f /tmp/pa_keys_$$
   log_print DEBUG "Created pa_socketrecords array with ${#pa_socketrecords[@]} entries"
 else


### PR DESCRIPTION
## What

`pf-process_sbs.sh` builds `/tmp/pa_keys_$$` from the Plane-Alert list (one anchored `^ICAO,` regex per entry plus the squawk patterns) and runs `grep -E -f` over the filtered SBS records to find Plane-Alert hits. This PR replaces that grep with an awk hash join keyed on field 1 (ICAO) and field 9 (squawk).

## Why

With the default Plane-Alert list the pattern file has tens of thousands of alternatives. GNU grep compiles them into a single automaton on every run, before it reads the first record, and that compile step dominates: in our testing about 11 s of CPU per run, roughly a third of the container's CPU use, on an input of a few hundred records. The cost scales with the size of the list, not with the number of records, so every instance pays it on every `PF_INTERVAL`.

The awk join loads the list into an associative array once and checks each record in constant time. The same step now takes under 0.2 s.

## Behaviour

- Output lines and their order are identical to the grep version, verified with `cmp` on live records against the same list and squawk set.
- `^ICAO,` patterns become `$1 in key`; `^([^,]*,){8}SQUAWK(,|$)` patterns become `$9 == squawk`. The header line of the list is skipped as before.
- If `PA_FILE` is missing, the join reads `/dev/null` as the list, so squawk-only matching still works the way it did with the grep version.
- `/tmp/pa_keys_$$` is still built and still gates the block on `wc -l`; nothing else in the flow changes.

## Testing

Ran the old and the new command side by side on a live `/run/socket30003` capture with the current `plane-alert-db.txt` and the default `PF_PA_SQUAWKS`; `cmp` reported no difference. `shellcheck` is clean on the changed file.
