### PR TITLE
fix(openskydb): back off for six hours when the OpenSky host is unreachable

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/get-openskydb
+++ b/rootfs/etc/s6-overlay/scripts/get-openskydb
@@ -41,18 +41,23 @@ else
   savedfile_date="1970-01"
 fi
 
-if ! latestfile="$(curl -sfL https://s3.opensky-network.org/data-samples/#metadata/ | grep -oP '(?<=\<Key\>metadata/)aircraft-database-complete.*?(?=\</Key\>)' | sort -ur | head -1)"; then
-  log_print ERR "Cannot reach the OpenSky web server to check if a newer OpenSky DB is available. Aborting update attempt."
+if ! latestfile="$(curl -sfL -m 30 https://s3.opensky-network.org/data-samples/#metadata/ | grep -oP '(?<=\<Key\>metadata/)aircraft-database-complete.*?(?=\</Key\>)' | sort -ur | head -1)"; then
+  log_print ERR "Cannot reach the OpenSky web server to check if a newer OpenSky DB is available. Next attempt in 6 hours."
   if [[ ! -f /run/OpenSkyDB.csv ]] && [[ -f "/usr/share/planefence/persist/.internal/$savedfile" ]]; then
     ln -sf "/usr/share/planefence/persist/.internal/$savedfile" "/run/OpenSkyDB.csv"
   fi
+  # s6 restarts this longrun as soon as it exits. Without a curl timeout each attempt
+  # hangs in TCP retries for about two minutes while the host is unreachable, so the
+  # service logged this error every couple of minutes. Wait six hours before the next
+  # attempt instead. The background sleep keeps bash responsive to SIGTERM on shutdown.
+  sleep 21600 & wait $!
   exit
 fi
 latestfile_date="$(sed 's|aircraft-database-complete-\([0-9-]\+\).*$|\1|g' <<< "$latestfile")"
 
 if (( ${savedfile_date//-/} < ${latestfile_date//-/} )); then
   log_print INFO "Newer OpenSky database ($latestfile_date) available. Downloading it now"
-  if curl -sfL --compressed "https://s3.opensky-network.org/data-samples/metadata/$latestfile" > "/tmp/$latestfile"; then
+  if curl -sfL -m 900 --compressed "https://s3.opensky-network.org/data-samples/metadata/$latestfile" > "/tmp/$latestfile"; then
     find /usr/share/planefence/stage/ -type f -name "aircraft-database-complete-*.csv" -delete
     find /usr/share/planefence/persist/.internal/ -type f -name "aircraft-database-complete-*.csv" -delete
     find /usr/share/planefence/html/ -type f -name "aircraft-database-complete-*.csv" -delete


### PR DESCRIPTION
## What

`get-openskydb` gets a timeout on both `curl` calls and waits six hours after a failed availability check before it exits and lets s6 restart it.

## Why

`s3.opensky-network.org`, where the aircraft database is hosted, has been unreachable since at least late August 2026 (connection refused or timeouts). OpenSky's database page says the dataset "is not up to date" and "may be made available again at a further date": https://opensky-network.org/data/aircraft

With the host down, the current script does this on every container:

- `curl` has no timeout, so the listing request hangs in TCP retries for about two minutes;
- the script then exits, and s6 restarts the longrun immediately;
- so there is a hanging `curl` process at all times and a `[FATAL] Cannot reach the OpenSky web server` line every couple of minutes.

## Behaviour

- Listing request: `-m 30`. Database download: `-m 900`, since the file is over 100 MB.
- After a failed check the script waits six hours (`sleep 21600 & wait $!`, so SIGTERM on shutdown is handled right away), then exits; s6 restarts it and it checks again. The log message says so.
- The symlink fallback to the last saved `aircraft-database-complete-*.csv` and the whole success path are unchanged, so once the host is back the update picks up on the next attempt.

## Testing

Deployed on a running container: one `[FATAL]` line at start, then no further attempts and no hanging `curl` in the following 25 minutes; `/run/OpenSkyDB.csv` still points at the saved database. `shellcheck` is clean on the changed file.
